### PR TITLE
feat: add payment request methods to PeerPayClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [2.0.7 - 2026-04-08](#207---2026-04-08)
 - [2.0.0 - 2026-02-06](#200---2026-02-06)
 - [Template for New Releases](#template-for-new-releases)
 
@@ -29,9 +30,9 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 
 - Payment request methods on PeerPayClient:
-  - `requestPayment()` — send a payment request to a recipient
-  - `cancelPaymentRequest()` — cancel a pending request
-  - `listIncomingPaymentRequests()` — list requests with expiry, cancellation, and min/max amount filtering
+  - `requestPayment()` — send a payment request with HMAC-based authorization proof
+  - `cancelPaymentRequest()` — cancel a pending request (requires original requestProof)
+  - `listIncomingPaymentRequests()` — list requests with HMAC verification, expiry, cancellation, and amount filtering (defaults: min 1000, max 10M sats)
   - `fulfillPaymentRequest()` — pay a request and send status response
   - `declinePaymentRequest()` — decline a request with optional note
   - `listPaymentRequestResponses()` — list responses to outgoing requests
@@ -42,9 +43,15 @@ All notable changes to this project will be documented in this file. The format 
   - `blockPaymentRequestsFrom()` — block an identity
   - `listPaymentRequestPermissions()` — list whitelisted/blocked identities
 - New message box constants: `PAYMENT_REQUESTS_MESSAGEBOX`, `PAYMENT_REQUEST_RESPONSES_MESSAGEBOX`
-- New types: `PaymentRequestMessage`, `PaymentRequestResponse`, `IncomingPaymentRequest`, `PaymentRequestLimits`
-- Unit tests for all 11 new methods
-- Integration tests for full round-trip payment request flows
+- New types: `PaymentRequestMessage` (discriminated union), `PaymentRequestResponse`, `IncomingPaymentRequest`, `PaymentRequestLimits`
+- Default limit constants: `DEFAULT_PAYMENT_REQUEST_MIN_AMOUNT`, `DEFAULT_PAYMENT_REQUEST_MAX_AMOUNT`
+- Unit and integration tests for all payment request methods
+
+### Security
+
+- Payment request cancellations are now authorized via HMAC proof — only the original sender can cancel a request
+- Malformed message bodies are validated and discarded instead of silently becoming ghost entries
+- Cancellation sender verification prevents cross-sender cancellation spoofing
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,30 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [2.0.7] - 2026-04-08
+
+### Added
+
+- Payment request methods on PeerPayClient:
+  - `requestPayment()` — send a payment request to a recipient
+  - `cancelPaymentRequest()` — cancel a pending request
+  - `listIncomingPaymentRequests()` — list requests with expiry, cancellation, and min/max amount filtering
+  - `fulfillPaymentRequest()` — pay a request and send status response
+  - `declinePaymentRequest()` — decline a request with optional note
+  - `listPaymentRequestResponses()` — list responses to outgoing requests
+  - `listenForLivePaymentRequests()` — WebSocket listener for incoming requests
+  - `listenForLivePaymentRequestResponses()` — WebSocket listener for responses
+- Permission management for payment requests:
+  - `allowPaymentRequestsFrom()` — whitelist an identity
+  - `blockPaymentRequestsFrom()` — block an identity
+  - `listPaymentRequestPermissions()` — list whitelisted/blocked identities
+- New message box constants: `PAYMENT_REQUESTS_MESSAGEBOX`, `PAYMENT_REQUEST_RESPONSES_MESSAGEBOX`
+- New types: `PaymentRequestMessage`, `PaymentRequestResponse`, `IncomingPaymentRequest`, `PaymentRequestLimits`
+- Unit tests for all 11 new methods
+- Integration tests for full round-trip payment request flows
+
+---
+
 ## [2.0.1] - 2026-02-16
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/message-box-client",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "publishConfig": {
     "access": "public"
   },

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -116,6 +116,55 @@ export class PeerPayClient extends MessageBoxClient {
   }
 
   /**
+   * Allows payment requests from a specific identity key by setting
+   * the recipientFee to 0 for the payment_requests message box.
+   *
+   * @param {Object} params - Parameters.
+   * @param {string} params.identityKey - The identity key to allow payment requests from.
+   * @returns {Promise<void>} Resolves when the permission is set.
+   */
+  async allowPaymentRequestsFrom ({ identityKey }: { identityKey: string }): Promise<void> {
+    await this.setMessageBoxPermission({
+      messageBox: PAYMENT_REQUESTS_MESSAGEBOX,
+      sender: identityKey,
+      recipientFee: 0
+    })
+  }
+
+  /**
+   * Blocks payment requests from a specific identity key by setting
+   * the recipientFee to -1 for the payment_requests message box.
+   *
+   * @param {Object} params - Parameters.
+   * @param {string} params.identityKey - The identity key to block payment requests from.
+   * @returns {Promise<void>} Resolves when the permission is set.
+   */
+  async blockPaymentRequestsFrom ({ identityKey }: { identityKey: string }): Promise<void> {
+    await this.setMessageBoxPermission({
+      messageBox: PAYMENT_REQUESTS_MESSAGEBOX,
+      sender: identityKey,
+      recipientFee: -1
+    })
+  }
+
+  /**
+   * Lists all permissions for the payment_requests message box, mapped to
+   * a simplified { identityKey, allowed } structure.
+   *
+   * A permission is considered "allowed" if recipientFee >= 0 (0 = always allow,
+   * positive = payment required). A recipientFee of -1 means blocked.
+   *
+   * @returns {Promise<Array<{ identityKey: string, allowed: boolean }>>} Resolved with the list of permissions.
+   */
+  async listPaymentRequestPermissions (): Promise<Array<{ identityKey: string, allowed: boolean }>> {
+    const permissions = await this.listMessageBoxPermissions({ messageBox: PAYMENT_REQUESTS_MESSAGEBOX })
+    return permissions.map(p => ({
+      identityKey: p.sender ?? '',
+      allowed: p.recipientFee >= 0
+    }))
+  }
+
+  /**
    * Generates a valid payment token for a recipient.
    *
    * This function derives a unique public key for the recipient, constructs a P2PKH locking script,

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -11,8 +11,8 @@
  */
 
 import { MessageBoxClient } from './MessageBoxClient.js'
-import { PeerMessage } from './types.js'
-import { WalletInterface, AtomicBEEF, AuthFetch, Base64String, OriginatorDomainNameStringUnder250Bytes, Brc29RemittanceModule } from '@bsv/sdk'
+import { PeerMessage, PaymentRequestMessage, PaymentRequestResponse, IncomingPaymentRequest, PaymentRequestLimits } from './types.js'
+import { WalletInterface, AtomicBEEF, AuthFetch, Base64String, OriginatorDomainNameStringUnder250Bytes, Brc29RemittanceModule, createNonce } from '@bsv/sdk'
 
 import * as Logger from './Utils/logger.js'
 
@@ -32,6 +32,8 @@ function safeParse<T> (input: any): T {
 }
 
 export const STANDARD_PAYMENT_MESSAGEBOX = 'payment_inbox'
+export const PAYMENT_REQUESTS_MESSAGEBOX = 'payment_requests'
+export const PAYMENT_REQUEST_RESPONSES_MESSAGEBOX = 'payment_request_responses'
 const STANDARD_PAYMENT_OUTPUT_INDEX = 0
 
 /**
@@ -159,8 +161,8 @@ export class PeerPayClient extends MessageBoxClient {
 
     return {
       customInstructions: {
-        derivationPrefix: result.artifact.customInstructions.derivationPrefix as Base64String,
-        derivationSuffix: result.artifact.customInstructions.derivationSuffix as Base64String
+        derivationPrefix: result.artifact.customInstructions.derivationPrefix,
+        derivationSuffix: result.artifact.customInstructions.derivationSuffix
       },
       transaction: result.artifact.transaction as AtomicBEEF,
       amount: result.artifact.amountSatoshis
@@ -405,5 +407,78 @@ export class PeerPayClient extends MessageBoxClient {
         token: parsedToken
       }
     })
+  }
+
+  /**
+   * Sends a payment request to a recipient via the payment_requests message box.
+   *
+   * Generates a unique requestId using createNonce, looks up the caller's identity key,
+   * and sends a PaymentRequestMessage to the recipient.
+   *
+   * @param {Object} params - Payment request parameters.
+   * @param {string} params.recipient - The identity key of the intended payer.
+   * @param {number} params.amount - The amount in satoshis being requested (must be > 0).
+   * @param {string} params.description - Human-readable reason for the payment request.
+   * @param {number} params.expiresAt - Unix timestamp (ms) when the request expires.
+   * @param {string} [hostOverride] - Optional host override for the message box server.
+   * @returns {Promise<{ requestId: string }>} The generated requestId for this request.
+   * @throws {Error} If amount is <= 0.
+   */
+  async requestPayment (
+    params: { recipient: string, amount: number, description: string, expiresAt: number },
+    hostOverride?: string
+  ): Promise<{ requestId: string }> {
+    if (params.amount <= 0) {
+      throw new Error('Invalid payment request: amount must be greater than 0')
+    }
+
+    const requestId = await createNonce(this.peerPayWalletClient, this.originator)
+    const senderIdentityKey = await this.getIdentityKey()
+
+    const body: PaymentRequestMessage = {
+      requestId,
+      amount: params.amount,
+      description: params.description,
+      expiresAt: params.expiresAt,
+      senderIdentityKey
+    }
+
+    await this.sendMessage({
+      recipient: params.recipient,
+      messageBox: PAYMENT_REQUESTS_MESSAGEBOX,
+      body: JSON.stringify(body)
+    }, hostOverride)
+
+    return { requestId }
+  }
+
+  /**
+   * Cancels a previously sent payment request by sending a cancellation message
+   * with the same requestId and `cancelled: true`.
+   *
+   * @param {Object} params - Cancellation parameters.
+   * @param {string} params.recipient - The identity key of the recipient of the original request.
+   * @param {string} params.requestId - The requestId of the payment request to cancel.
+   * @param {string} [hostOverride] - Optional host override for the message box server.
+   * @returns {Promise<void>} Resolves when the cancellation message has been sent.
+   */
+  async cancelPaymentRequest (
+    params: { recipient: string, requestId: string },
+    hostOverride?: string
+  ): Promise<void> {
+    const body: PaymentRequestMessage = {
+      requestId: params.requestId,
+      amount: 0,
+      description: '',
+      expiresAt: 0,
+      senderIdentityKey: '',
+      cancelled: true
+    }
+
+    await this.sendMessage({
+      recipient: params.recipient,
+      messageBox: PAYMENT_REQUESTS_MESSAGEBOX,
+      body: JSON.stringify(body)
+    }, hostOverride)
   }
 }

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -37,6 +37,7 @@ function isValidPaymentRequestMessage (obj: any): obj is PaymentRequestMessage {
   if (typeof obj !== 'object' || obj === null) return false
   if (typeof obj.requestId !== 'string') return false
   if (typeof obj.senderIdentityKey !== 'string') return false
+  if (typeof obj.requestProof !== 'string') return false
   if (obj.cancelled === true) return true
   return typeof obj.amount === 'number' && typeof obj.description === 'string' && typeof obj.expiresAt === 'number'
 }
@@ -639,7 +640,7 @@ export class PeerPayClient extends MessageBoxClient {
   async requestPayment (
     params: { recipient: string, amount: number, description: string, expiresAt: number },
     hostOverride?: string
-  ): Promise<{ requestId: string }> {
+  ): Promise<{ requestId: string, requestProof: string }> {
     if (params.amount <= 0) {
       throw new Error('Invalid payment request: amount must be greater than 0')
     }
@@ -647,12 +648,22 @@ export class PeerPayClient extends MessageBoxClient {
     const requestId = await createNonce(this.peerPayWalletClient, 'self', this.originator)
     const senderIdentityKey = await this.getIdentityKey()
 
+    const proofData = Array.from(new TextEncoder().encode(requestId + params.recipient))
+    const { hmac } = await this.peerPayWalletClient.createHmac({
+      data: proofData,
+      protocolID: [2, 'payment request auth'],
+      keyID: requestId,
+      counterparty: params.recipient
+    }, this.originator)
+    const requestProof = Array.from(hmac).map(b => b.toString(16).padStart(2, '0')).join('')
+
     const body: PaymentRequestMessage = {
       requestId,
       amount: params.amount,
       description: params.description,
       expiresAt: params.expiresAt,
-      senderIdentityKey
+      senderIdentityKey,
+      requestProof
     }
 
     try {
@@ -669,7 +680,7 @@ export class PeerPayClient extends MessageBoxClient {
       throw err
     }
 
-    return { requestId }
+    return { requestId, requestProof }
   }
 
   /**
@@ -690,6 +701,7 @@ export class PeerPayClient extends MessageBoxClient {
     limits?: PaymentRequestLimits
   ): Promise<IncomingPaymentRequest[]> {
     const messages = await this.listMessages({ messageBox: PAYMENT_REQUESTS_MESSAGEBOX, host: hostOverride })
+    const myIdentityKey = await this.getIdentityKey()
     const now = Date.now()
 
     // Parse and validate all messages, collecting malformed ones for ack
@@ -705,13 +717,28 @@ export class PeerPayClient extends MessageBoxClient {
       }
     }
 
-    // Collect cancelled requestIds — only from same sender (prevents spoofing)
+    // Collect cancelled requestIds — verify HMAC proof before accepting
     const cancelledRequests = new Map<string, string>() // requestId → sender
     const cancelMessageIds: string[] = []
     for (const item of parsed) {
       if (item.body.cancelled === true) {
-        cancelledRequests.set(item.body.requestId, item.sender)
-        cancelMessageIds.push(item.messageId)
+        // Verify cancellation HMAC proof
+        try {
+          const proofData = Array.from(new TextEncoder().encode(item.body.requestId + myIdentityKey))
+          await this.peerPayWalletClient.verifyHmac({
+            data: proofData,
+            hmac: Array.from(Buffer.from(item.body.requestProof, 'hex')),
+            protocolID: [2, 'payment request auth'],
+            keyID: item.body.requestId,
+            counterparty: item.sender
+          }, this.originator)
+          cancelledRequests.set(item.body.requestId, item.sender)
+          cancelMessageIds.push(item.messageId)
+        } catch {
+          Logger.warn(`[PP CLIENT] Invalid cancellation proof for requestId=${item.body.requestId}, discarding`)
+          malformedMessageIds.push(item.messageId)
+        }
+        continue
       }
     }
 
@@ -743,6 +770,22 @@ export class PeerPayClient extends MessageBoxClient {
       const effectiveMax = limits?.maxAmount ?? DEFAULT_PAYMENT_REQUEST_MAX_AMOUNT
       if (amount < effectiveMin || amount > effectiveMax) {
         outOfRangeMessageIds.push(item.messageId)
+        continue
+      }
+
+      // Verify HMAC proof — ensures message came from claimed sender
+      try {
+        const proofData = Array.from(new TextEncoder().encode(requestId + myIdentityKey))
+        await this.peerPayWalletClient.verifyHmac({
+          data: proofData,
+          hmac: Array.from(Buffer.from(item.body.requestProof, 'hex')),
+          protocolID: [2, 'payment request auth'],
+          keyID: requestId,
+          counterparty: item.sender
+        }, this.originator)
+      } catch {
+        Logger.warn(`[PP CLIENT] Invalid requestProof for requestId=${requestId}, discarding`)
+        malformedMessageIds.push(item.messageId)
         continue
       }
 
@@ -791,7 +834,7 @@ export class PeerPayClient extends MessageBoxClient {
    * @returns {Promise<void>} Resolves when the cancellation message has been sent.
    */
   async cancelPaymentRequest (
-    params: { recipient: string, requestId: string },
+    params: { recipient: string, requestId: string, requestProof: string },
     hostOverride?: string
   ): Promise<void> {
     const senderIdentityKey = await this.getIdentityKey()
@@ -799,6 +842,7 @@ export class PeerPayClient extends MessageBoxClient {
     const body: PaymentRequestMessage = {
       requestId: params.requestId,
       senderIdentityKey,
+      requestProof: params.requestProof,
       cancelled: true
     }
 

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -20,15 +20,25 @@ function toNumberArray (tx: AtomicBEEF): number[] {
   return Array.isArray(tx) ? tx : Array.from(tx)
 }
 
-function safeParse<T> (input: any): T {
+function safeParse<T> (input: any): T | undefined {
   try {
     return typeof input === 'string' ? JSON.parse(input) : input
   } catch (e) {
     Logger.error('[PP CLIENT] Failed to parse input in safeParse:', input)
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const fallback = {} as T
-    return fallback
+    return undefined
   }
+}
+
+/**
+ * Validates that a parsed object has the required fields for a PaymentRequestMessage.
+ * Returns true for both new requests (has amount, description, expiresAt) and cancellations (has cancelled: true).
+ */
+function isValidPaymentRequestMessage (obj: any): obj is PaymentRequestMessage {
+  if (typeof obj !== 'object' || obj === null) return false
+  if (typeof obj.requestId !== 'string') return false
+  if (typeof obj.senderIdentityKey !== 'string') return false
+  if (obj.cancelled === true) return true
+  return typeof obj.amount === 'number' && typeof obj.description === 'string' && typeof obj.expiresAt === 'number'
 }
 
 export const STANDARD_PAYMENT_MESSAGEBOX = 'payment_inbox'
@@ -312,10 +322,12 @@ export class PeerPayClient extends MessageBoxClient {
       // Convert PeerMessage → IncomingPayment before calling onPayment
       onMessage: (message: PeerMessage) => {
         Logger.log('[MB CLIENT] Received Live Payment:', message)
+        const token = safeParse<PaymentToken>(message.body)
+        if (token == null) return
         const incomingPayment: IncomingPayment = {
           messageId: message.messageId,
           sender: message.sender,
-          token: safeParse<PaymentToken>(message.body)
+          token
         }
         Logger.log('[PP CLIENT] Converted PeerMessage to IncomingPayment:', incomingPayment)
         onPayment(incomingPayment)
@@ -453,13 +465,14 @@ export class PeerPayClient extends MessageBoxClient {
     const messages = await this.listMessages({ messageBox: this.messageBox, host: overrideHost })
     return messages.map((msg: any) => {
       const parsedToken = safeParse<PaymentToken>(msg.body)
+      if (parsedToken == null) return null
 
       return {
         messageId: msg.messageId,
         sender: msg.sender,
         token: parsedToken
       }
-    })
+    }).filter((p): p is IncomingPayment => p != null)
   }
 
   /**
@@ -473,6 +486,7 @@ export class PeerPayClient extends MessageBoxClient {
   async listPaymentRequestResponses (hostOverride?: string): Promise<PaymentRequestResponse[]> {
     const messages = await this.listMessages({ messageBox: PAYMENT_REQUEST_RESPONSES_MESSAGEBOX, host: hostOverride })
     return messages.map((msg: any) => safeParse<PaymentRequestResponse>(msg.body))
+      .filter((r): r is PaymentRequestResponse => r != null)
   }
 
   /**
@@ -535,6 +549,7 @@ export class PeerPayClient extends MessageBoxClient {
       overrideHost,
       onMessage: (message: PeerMessage) => {
         const response = safeParse<PaymentRequestResponse>(message.body)
+        if (response == null) return
         onResponse(response)
       }
     })
@@ -677,19 +692,25 @@ export class PeerPayClient extends MessageBoxClient {
     const messages = await this.listMessages({ messageBox: PAYMENT_REQUESTS_MESSAGEBOX, host: hostOverride })
     const now = Date.now()
 
-    // Parse all messages
-    const parsed = messages.map((msg: any) => ({
-      messageId: msg.messageId as string,
-      sender: msg.sender as string,
-      body: safeParse<PaymentRequestMessage>(msg.body)
-    }))
+    // Parse and validate all messages, collecting malformed ones for ack
+    const malformedMessageIds: string[] = []
+    const parsed: Array<{ messageId: string, sender: string, body: PaymentRequestMessage }> = []
 
-    // Collect cancelled requestIds and their cancel message IDs
-    const cancelledRequestIds = new Set<string>()
+    for (const msg of messages) {
+      const body = safeParse<PaymentRequestMessage>(msg.body)
+      if (body != null && isValidPaymentRequestMessage(body)) {
+        parsed.push({ messageId: msg.messageId as string, sender: msg.sender as string, body })
+      } else {
+        malformedMessageIds.push(msg.messageId as string)
+      }
+    }
+
+    // Collect cancelled requestIds — only from same sender (prevents spoofing)
+    const cancelledRequests = new Map<string, string>() // requestId → sender
     const cancelMessageIds: string[] = []
     for (const item of parsed) {
       if (item.body.cancelled === true) {
-        cancelledRequestIds.add(item.body.requestId)
+        cancelledRequests.set(item.body.requestId, item.sender)
         cancelMessageIds.push(item.messageId)
       }
     }
@@ -711,18 +732,18 @@ export class PeerPayClient extends MessageBoxClient {
         continue
       }
 
-      // Filter cancelled originals
-      if (cancelledRequestIds.has(requestId)) {
+      // Filter cancelled originals — only if cancellation came from the same sender
+      if (cancelledRequests.has(requestId) && cancelledRequests.get(requestId) === item.sender) {
         cancelledOriginalMessageIds.push(item.messageId)
         continue
       }
 
-      // Filter out-of-range when limits provided
-      if (limits != null) {
-        if (amount < limits.minAmount || amount > limits.maxAmount) {
-          outOfRangeMessageIds.push(item.messageId)
-          continue
-        }
+      // Filter out-of-range — apply defaults for any missing limit fields
+      const effectiveMin = limits?.minAmount ?? DEFAULT_PAYMENT_REQUEST_MIN_AMOUNT
+      const effectiveMax = limits?.maxAmount ?? DEFAULT_PAYMENT_REQUEST_MAX_AMOUNT
+      if (amount < effectiveMin || amount > effectiveMax) {
+        outOfRangeMessageIds.push(item.messageId)
+        continue
       }
 
       active.push({
@@ -737,18 +758,23 @@ export class PeerPayClient extends MessageBoxClient {
 
     // Acknowledge expired
     if (expiredMessageIds.length > 0) {
-      await this.acknowledgeMessage({ messageIds: expiredMessageIds })
+      await this.acknowledgeMessage({ messageIds: expiredMessageIds, host: hostOverride })
     }
 
     // Acknowledge cancelled originals + cancel messages together
     const cancelAckIds = [...cancelledOriginalMessageIds, ...cancelMessageIds]
     if (cancelAckIds.length > 0) {
-      await this.acknowledgeMessage({ messageIds: cancelAckIds })
+      await this.acknowledgeMessage({ messageIds: cancelAckIds, host: hostOverride })
     }
 
     // Acknowledge out-of-range
     if (outOfRangeMessageIds.length > 0) {
-      await this.acknowledgeMessage({ messageIds: outOfRangeMessageIds })
+      await this.acknowledgeMessage({ messageIds: outOfRangeMessageIds, host: hostOverride })
+    }
+
+    // Acknowledge malformed messages so they don't reappear
+    if (malformedMessageIds.length > 0) {
+      await this.acknowledgeMessage({ messageIds: malformedMessageIds, host: hostOverride })
     }
 
     return active

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -642,11 +642,19 @@ export class PeerPayClient extends MessageBoxClient {
       senderIdentityKey
     }
 
-    await this.sendMessage({
-      recipient: params.recipient,
-      messageBox: PAYMENT_REQUESTS_MESSAGEBOX,
-      body: JSON.stringify(body)
-    }, hostOverride)
+    try {
+      await this.sendMessage({
+        recipient: params.recipient,
+        messageBox: PAYMENT_REQUESTS_MESSAGEBOX,
+        body: JSON.stringify(body)
+      }, hostOverride)
+    } catch (err: any) {
+      // Translate HTTP 403 (permission denied) into a user-friendly message.
+      if (typeof err?.message === 'string' && err.message.includes('403')) {
+        throw new Error('Payment request blocked — you are not on the recipient\'s whitelist.')
+      }
+      throw err
+    }
 
     return { requestId }
   }

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -20,6 +20,11 @@ function toNumberArray (tx: AtomicBEEF): number[] {
   return Array.isArray(tx) ? tx : Array.from(tx)
 }
 
+function hexToBytes (hex: string): number[] {
+  const matches = hex.match(/.{1,2}/g)
+  return matches != null ? matches.map(byte => parseInt(byte, 16)) : []
+}
+
 function safeParse<T> (input: any): T | undefined {
   try {
     return typeof input === 'string' ? JSON.parse(input) : input
@@ -727,7 +732,7 @@ export class PeerPayClient extends MessageBoxClient {
           const proofData = Array.from(new TextEncoder().encode(item.body.requestId + myIdentityKey))
           await this.peerPayWalletClient.verifyHmac({
             data: proofData,
-            hmac: Array.from(Buffer.from(item.body.requestProof, 'hex')),
+            hmac: hexToBytes(item.body.requestProof),
             protocolID: [2, 'payment request auth'],
             keyID: item.body.requestId,
             counterparty: item.sender
@@ -778,7 +783,7 @@ export class PeerPayClient extends MessageBoxClient {
         const proofData = Array.from(new TextEncoder().encode(requestId + myIdentityKey))
         await this.peerPayWalletClient.verifyHmac({
           data: proofData,
-          hmac: Array.from(Buffer.from(item.body.requestProof, 'hex')),
+          hmac: hexToBytes(item.body.requestProof),
           protocolID: [2, 'payment request auth'],
           keyID: requestId,
           counterparty: item.sender

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -627,7 +627,7 @@ export class PeerPayClient extends MessageBoxClient {
       throw new Error('Invalid payment request: amount must be greater than 0')
     }
 
-    const requestId = await createNonce(this.peerPayWalletClient, this.originator)
+    const requestId = await createNonce(this.peerPayWalletClient, 'self', this.originator)
     const senderIdentityKey = await this.getIdentityKey()
 
     const body: PaymentRequestMessage = {

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -453,6 +453,103 @@ export class PeerPayClient extends MessageBoxClient {
   }
 
   /**
+   * Lists all incoming payment requests from the payment_requests message box.
+   *
+   * Automatically filters out:
+   * - Expired requests (expiresAt < now), which are acknowledged and discarded.
+   * - Cancelled requests (a cancellation message with the same requestId exists),
+   *   both the original and cancellation messages are acknowledged and discarded.
+   * - Out-of-range requests (when limits are provided), which are acknowledged and discarded.
+   *
+   * @param {string} [hostOverride] - Optional host override for the message box server.
+   * @param {PaymentRequestLimits} [limits] - Optional min/max satoshi limits for filtering.
+   * @returns {Promise<IncomingPaymentRequest[]>} Resolves with active, valid payment requests.
+   */
+  async listIncomingPaymentRequests (
+    hostOverride?: string,
+    limits?: PaymentRequestLimits
+  ): Promise<IncomingPaymentRequest[]> {
+    const messages = await this.listMessages({ messageBox: PAYMENT_REQUESTS_MESSAGEBOX, host: hostOverride })
+    const now = Date.now()
+
+    // Parse all messages
+    const parsed = messages.map((msg: any) => ({
+      messageId: msg.messageId as string,
+      sender: msg.sender as string,
+      body: safeParse<PaymentRequestMessage>(msg.body)
+    }))
+
+    // Collect cancelled requestIds and their cancel message IDs
+    const cancelledRequestIds = new Set<string>()
+    const cancelMessageIds: string[] = []
+    for (const item of parsed) {
+      if (item.body.cancelled === true) {
+        cancelledRequestIds.add(item.body.requestId)
+        cancelMessageIds.push(item.messageId)
+      }
+    }
+
+    const expiredMessageIds: string[] = []
+    const outOfRangeMessageIds: string[] = []
+    const cancelledOriginalMessageIds: string[] = []
+    const active: IncomingPaymentRequest[] = []
+
+    for (const item of parsed) {
+      // Skip cancellation messages themselves (already collected above)
+      if (item.body.cancelled === true) continue
+
+      const { requestId, amount, description, expiresAt } = item.body
+
+      // Filter expired
+      if (expiresAt < now) {
+        expiredMessageIds.push(item.messageId)
+        continue
+      }
+
+      // Filter cancelled originals
+      if (cancelledRequestIds.has(requestId)) {
+        cancelledOriginalMessageIds.push(item.messageId)
+        continue
+      }
+
+      // Filter out-of-range when limits provided
+      if (limits != null) {
+        if (amount < limits.minAmount || amount > limits.maxAmount) {
+          outOfRangeMessageIds.push(item.messageId)
+          continue
+        }
+      }
+
+      active.push({
+        messageId: item.messageId,
+        sender: item.sender,
+        requestId,
+        amount,
+        description,
+        expiresAt
+      })
+    }
+
+    // Acknowledge expired
+    if (expiredMessageIds.length > 0) {
+      await this.acknowledgeMessage({ messageIds: expiredMessageIds })
+    }
+
+    // Acknowledge cancelled originals + cancel messages together
+    const cancelAckIds = [...cancelledOriginalMessageIds, ...cancelMessageIds]
+    if (cancelAckIds.length > 0) {
+      await this.acknowledgeMessage({ messageIds: cancelAckIds })
+    }
+
+    // Acknowledge out-of-range
+    if (outOfRangeMessageIds.length > 0) {
+      await this.acknowledgeMessage({ messageIds: outOfRangeMessageIds })
+    }
+
+    return active
+  }
+
+  /**
    * Cancels a previously sent payment request by sending a cancellation message
    * with the same requestId and `cancelled: true`.
    *

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -410,6 +410,84 @@ export class PeerPayClient extends MessageBoxClient {
   }
 
   /**
+   * Lists all responses to payment requests from the payment_request_responses message box.
+   *
+   * Retrieves messages and parses each as a PaymentRequestResponse.
+   *
+   * @param {string} [hostOverride] - Optional host override for the message box server.
+   * @returns {Promise<PaymentRequestResponse[]>} Resolves with an array of payment request responses.
+   */
+  async listPaymentRequestResponses (hostOverride?: string): Promise<PaymentRequestResponse[]> {
+    const messages = await this.listMessages({ messageBox: PAYMENT_REQUEST_RESPONSES_MESSAGEBOX, host: hostOverride })
+    return messages.map((msg: any) => safeParse<PaymentRequestResponse>(msg.body))
+  }
+
+  /**
+   * Listens for incoming payment requests in real time via WebSocket.
+   *
+   * Wraps listenForLiveMessages on the payment_requests box and converts each
+   * incoming PeerMessage into an IncomingPaymentRequest before calling onRequest.
+   *
+   * @param {Object} params - Listener configuration.
+   * @param {Function} params.onRequest - Callback invoked when a new payment request arrives.
+   * @param {string} [params.overrideHost] - Optional host override for the WebSocket connection.
+   * @returns {Promise<void>} Resolves when the listener is established.
+   */
+  async listenForLivePaymentRequests ({
+    onRequest,
+    overrideHost
+  }: {
+    onRequest: (request: IncomingPaymentRequest) => void
+    overrideHost?: string
+  }): Promise<void> {
+    await this.listenForLiveMessages({
+      messageBox: PAYMENT_REQUESTS_MESSAGEBOX,
+      overrideHost,
+      onMessage: (message: PeerMessage) => {
+        const body = safeParse<PaymentRequestMessage>(message.body)
+        const request: IncomingPaymentRequest = {
+          messageId: message.messageId,
+          sender: message.sender,
+          requestId: body.requestId,
+          amount: body.amount,
+          description: body.description,
+          expiresAt: body.expiresAt,
+          cancelled: body.cancelled
+        }
+        onRequest(request)
+      }
+    })
+  }
+
+  /**
+   * Listens for payment request responses in real time via WebSocket.
+   *
+   * Wraps listenForLiveMessages on the payment_request_responses box and converts each
+   * incoming PeerMessage into a PaymentRequestResponse before calling onResponse.
+   *
+   * @param {Object} params - Listener configuration.
+   * @param {Function} params.onResponse - Callback invoked when a new response arrives.
+   * @param {string} [params.overrideHost] - Optional host override for the WebSocket connection.
+   * @returns {Promise<void>} Resolves when the listener is established.
+   */
+  async listenForLivePaymentRequestResponses ({
+    onResponse,
+    overrideHost
+  }: {
+    onResponse: (response: PaymentRequestResponse) => void
+    overrideHost?: string
+  }): Promise<void> {
+    await this.listenForLiveMessages({
+      messageBox: PAYMENT_REQUEST_RESPONSES_MESSAGEBOX,
+      overrideHost,
+      onMessage: (message: PeerMessage) => {
+        const response = safeParse<PaymentRequestResponse>(message.body)
+        onResponse(response)
+      }
+    })
+  }
+
+  /**
    * Fulfills an incoming payment request by sending the requested payment and
    * notifying the requester with a 'paid' response in the payment_request_responses box.
    * Also acknowledges the original request message.

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -158,10 +158,14 @@ export class PeerPayClient extends MessageBoxClient {
    */
   async listPaymentRequestPermissions (): Promise<Array<{ identityKey: string, allowed: boolean }>> {
     const permissions = await this.listMessageBoxPermissions({ messageBox: PAYMENT_REQUESTS_MESSAGEBOX })
-    return permissions.map(p => ({
-      identityKey: p.sender ?? '',
-      allowed: p.recipientFee >= 0
-    }))
+    // Filter to only per-sender entries (sender is not null/empty).
+    // Use the status field returned by the server to determine allowed state.
+    return permissions
+      .filter(p => p.sender != null && p.sender !== '')
+      .map(p => ({
+        identityKey: p.sender ?? '',
+        allowed: p.status !== 'blocked'
+      }))
   }
 
   /**

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -11,7 +11,7 @@
  */
 
 import { MessageBoxClient } from './MessageBoxClient.js'
-import { PeerMessage, PaymentRequestMessage, PaymentRequestResponse, IncomingPaymentRequest, PaymentRequestLimits } from './types.js'
+import { PeerMessage, PaymentRequestMessage, PaymentRequestResponse, IncomingPaymentRequest, PaymentRequestLimits, DEFAULT_PAYMENT_REQUEST_MIN_AMOUNT, DEFAULT_PAYMENT_REQUEST_MAX_AMOUNT } from './types.js'
 import { WalletInterface, AtomicBEEF, AuthFetch, Base64String, OriginatorDomainNameStringUnder250Bytes, Brc29RemittanceModule, createNonce } from '@bsv/sdk'
 
 import * as Logger from './Utils/logger.js'
@@ -498,14 +498,14 @@ export class PeerPayClient extends MessageBoxClient {
       overrideHost,
       onMessage: (message: PeerMessage) => {
         const body = safeParse<PaymentRequestMessage>(message.body)
+        if (body == null || body.cancelled === true) return // Skip cancellations and parse failures
         const request: IncomingPaymentRequest = {
           messageId: message.messageId,
           sender: message.sender,
           requestId: body.requestId,
           amount: body.amount,
           description: body.description,
-          expiresAt: body.expiresAt,
-          cancelled: body.cancelled
+          expiresAt: body.expiresAt
         }
         onRequest(request)
       }
@@ -547,24 +547,22 @@ export class PeerPayClient extends MessageBoxClient {
    *
    * @param {Object} params - Fulfillment parameters.
    * @param {IncomingPaymentRequest} params.request - The incoming payment request to fulfill.
-   * @param {number} [params.amount] - Optional amount override (defaults to request.amount).
    * @param {string} [params.note] - Optional note to include in the response.
    * @param {string} [hostOverride] - Optional host override for the message box server.
    * @returns {Promise<void>} Resolves when payment is sent and acknowledgment is complete.
    */
   async fulfillPaymentRequest (
-    params: { request: IncomingPaymentRequest, amount?: number, note?: string },
+    params: { request: IncomingPaymentRequest, note?: string },
     hostOverride?: string
   ): Promise<void> {
     const { request, note } = params
-    const amount = params.amount ?? request.amount
 
-    await this.sendPayment({ recipient: request.sender, amount }, hostOverride)
+    await this.sendPayment({ recipient: request.sender, amount: request.amount }, hostOverride)
 
     const response: PaymentRequestResponse = {
       requestId: request.requestId,
       status: 'paid',
-      amountPaid: amount,
+      amountPaid: request.amount,
       ...(note != null && { note })
     }
 
@@ -574,7 +572,7 @@ export class PeerPayClient extends MessageBoxClient {
       body: JSON.stringify(response)
     }, hostOverride)
 
-    await this.acknowledgeMessage({ messageIds: [request.messageId] })
+    await this.acknowledgeMessage({ messageIds: [request.messageId], host: hostOverride })
   }
 
   /**
@@ -605,7 +603,7 @@ export class PeerPayClient extends MessageBoxClient {
       body: JSON.stringify(response)
     }, hostOverride)
 
-    await this.acknowledgeMessage({ messageIds: [request.messageId] })
+    await this.acknowledgeMessage({ messageIds: [request.messageId], host: hostOverride })
   }
 
   /**
@@ -770,12 +768,11 @@ export class PeerPayClient extends MessageBoxClient {
     params: { recipient: string, requestId: string },
     hostOverride?: string
   ): Promise<void> {
+    const senderIdentityKey = await this.getIdentityKey()
+
     const body: PaymentRequestMessage = {
       requestId: params.requestId,
-      amount: 0,
-      description: '',
-      expiresAt: 0,
-      senderIdentityKey: '',
+      senderIdentityKey,
       cancelled: true
     }
 

--- a/src/PeerPayClient.ts
+++ b/src/PeerPayClient.ts
@@ -410,6 +410,74 @@ export class PeerPayClient extends MessageBoxClient {
   }
 
   /**
+   * Fulfills an incoming payment request by sending the requested payment and
+   * notifying the requester with a 'paid' response in the payment_request_responses box.
+   * Also acknowledges the original request message.
+   *
+   * @param {Object} params - Fulfillment parameters.
+   * @param {IncomingPaymentRequest} params.request - The incoming payment request to fulfill.
+   * @param {number} [params.amount] - Optional amount override (defaults to request.amount).
+   * @param {string} [params.note] - Optional note to include in the response.
+   * @param {string} [hostOverride] - Optional host override for the message box server.
+   * @returns {Promise<void>} Resolves when payment is sent and acknowledgment is complete.
+   */
+  async fulfillPaymentRequest (
+    params: { request: IncomingPaymentRequest, amount?: number, note?: string },
+    hostOverride?: string
+  ): Promise<void> {
+    const { request, note } = params
+    const amount = params.amount ?? request.amount
+
+    await this.sendPayment({ recipient: request.sender, amount }, hostOverride)
+
+    const response: PaymentRequestResponse = {
+      requestId: request.requestId,
+      status: 'paid',
+      amountPaid: amount,
+      ...(note != null && { note })
+    }
+
+    await this.sendMessage({
+      recipient: request.sender,
+      messageBox: PAYMENT_REQUEST_RESPONSES_MESSAGEBOX,
+      body: JSON.stringify(response)
+    }, hostOverride)
+
+    await this.acknowledgeMessage({ messageIds: [request.messageId] })
+  }
+
+  /**
+   * Declines an incoming payment request by notifying the requester with a 'declined'
+   * response in the payment_request_responses box and acknowledging the original request.
+   *
+   * @param {Object} params - Decline parameters.
+   * @param {IncomingPaymentRequest} params.request - The incoming payment request to decline.
+   * @param {string} [params.note] - Optional note explaining why the request was declined.
+   * @param {string} [hostOverride] - Optional host override for the message box server.
+   * @returns {Promise<void>} Resolves when the response is sent and request is acknowledged.
+   */
+  async declinePaymentRequest (
+    params: { request: IncomingPaymentRequest, note?: string },
+    hostOverride?: string
+  ): Promise<void> {
+    const { request, note } = params
+
+    const response: PaymentRequestResponse = {
+      requestId: request.requestId,
+      status: 'declined',
+      ...(note != null && { note })
+    }
+
+    await this.sendMessage({
+      recipient: request.sender,
+      messageBox: PAYMENT_REQUEST_RESPONSES_MESSAGEBOX,
+      body: JSON.stringify(response)
+    }, hostOverride)
+
+    await this.acknowledgeMessage({ messageIds: [request.messageId] })
+  }
+
+  /**
    * Sends a payment request to a recipient via the payment_requests message box.
    *
    * Generates a unique requestId using createNonce, looks up the caller's identity key,

--- a/src/__tests/PeerPayClientRequestIntegration.test.ts
+++ b/src/__tests/PeerPayClientRequestIntegration.test.ts
@@ -280,39 +280,9 @@ describe('PeerPayClient — Integration: payment request flow', () => {
   })
 
   // -------------------------------------------------------------------------
-  // Test 5: Modified amount — payer pays a different amount
+  // Test 5: Requests below minAmount are auto-acknowledged and excluded
   // -------------------------------------------------------------------------
-  it('Test 5: payer fulfills with a modified amount', async () => {
-    const requester = createWiredClient({ bus, identityKey: REQUESTER_KEY, walletClient: mockWalletRequester })
-    const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
-
-    const { requestId } = await requester.requestPayment({
-      recipient: PAYER_KEY,
-      amount: 5000,
-      description: 'Flexible request',
-      expiresAt: Date.now() + 60000
-    })
-
-    const incoming = await payer.listIncomingPaymentRequests()
-    expect(incoming).toHaveLength(1)
-
-    // Pay a different amount with a note
-    await payer.fulfillPaymentRequest({ request: incoming[0], amount: 4500, note: 'Partial payment' })
-
-    const responses = await requester.listPaymentRequestResponses()
-    expect(responses).toHaveLength(1)
-    expect(responses[0]).toMatchObject({
-      requestId,
-      status: 'paid',
-      amountPaid: 4500,
-      note: 'Partial payment'
-    })
-  })
-
-  // -------------------------------------------------------------------------
-  // Test 6: Requests below minAmount are auto-acknowledged and excluded
-  // -------------------------------------------------------------------------
-  it('Test 6: requests below minAmount are auto-acknowledged and excluded', async () => {
+  it('Test 5: requests below minAmount are auto-acknowledged and excluded', async () => {
     const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
 
     // Inject a request below the minAmount threshold
@@ -349,9 +319,9 @@ describe('PeerPayClient — Integration: payment request flow', () => {
   })
 
   // -------------------------------------------------------------------------
-  // Test 7: Requests above maxAmount are auto-acknowledged and excluded
+  // Test 6: Requests above maxAmount are auto-acknowledged and excluded
   // -------------------------------------------------------------------------
-  it('Test 7: requests above maxAmount are auto-acknowledged and excluded', async () => {
+  it('Test 6: requests above maxAmount are auto-acknowledged and excluded', async () => {
     const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
 
     // Inject a request above the maxAmount threshold

--- a/src/__tests/PeerPayClientRequestIntegration.test.ts
+++ b/src/__tests/PeerPayClientRequestIntegration.test.ts
@@ -27,7 +27,8 @@ jest.mock('@bsv/sdk', () => {
       internalizeAction: jest.fn(),
       createHmac: jest.fn<() => Promise<CreateHmacResult>>().mockResolvedValue({
         hmac: [1, 2, 3, 4, 5]
-      })
+      }),
+      verifyHmac: jest.fn<() => Promise<{ valid: true }>>().mockResolvedValue({ valid: true as const })
     }))
   }
 })
@@ -159,13 +160,9 @@ describe('PeerPayClient — Integration: payment request flow', () => {
 
     mockWalletRequester = new WalletClient() as jest.Mocked<WalletClient>
     mockWalletRequester.getPublicKey.mockResolvedValue({ publicKey: REQUESTER_KEY })
-    mockWalletRequester.createHmac = jest.fn<() => Promise<CreateHmacResult>>().mockResolvedValue({ hmac: [1, 2, 3, 4, 5] })
-    mockWalletRequester.verifyHmac = jest.fn().mockResolvedValue({ valid: true })
 
     mockWalletPayer = new WalletClient() as jest.Mocked<WalletClient>
     mockWalletPayer.getPublicKey.mockResolvedValue({ publicKey: PAYER_KEY })
-    mockWalletPayer.createHmac = jest.fn<() => Promise<CreateHmacResult>>().mockResolvedValue({ hmac: [1, 2, 3, 4, 5] })
-    mockWalletPayer.verifyHmac = jest.fn().mockResolvedValue({ valid: true })
   })
 
   // -------------------------------------------------------------------------

--- a/src/__tests/PeerPayClientRequestIntegration.test.ts
+++ b/src/__tests/PeerPayClientRequestIntegration.test.ts
@@ -1,0 +1,389 @@
+/* eslint-env jest */
+/**
+ * Integration tests for the PeerPayClient payment request flow.
+ *
+ * Uses a MockMessageBus to simulate the MessageBox server in memory,
+ * wiring the PeerPayClient methods (sendMessage, listMessages, acknowledgeMessage,
+ * getIdentityKey) to the mock bus so that full round-trip flows can be tested
+ * without hitting a real server.
+ */
+
+import { PeerPayClient, PAYMENT_REQUESTS_MESSAGEBOX, PAYMENT_REQUEST_RESPONSES_MESSAGEBOX, STANDARD_PAYMENT_MESSAGEBOX } from '../PeerPayClient.js'
+import { PeerMessage } from '../types.js'
+import { PrivateKey, CreateHmacResult, WalletClient } from '@bsv/sdk'
+import { jest } from '@jest/globals'
+
+// ---------------------------------------------------------------------------
+// Mock @bsv/sdk the same way as PeerPayClientUnit.test.ts
+// ---------------------------------------------------------------------------
+jest.mock('@bsv/sdk', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const actualSDK = jest.requireActual('@bsv/sdk') as any
+  return {
+    ...actualSDK,
+    WalletClient: jest.fn().mockImplementation(() => ({
+      getPublicKey: jest.fn(),
+      createAction: jest.fn(),
+      internalizeAction: jest.fn(),
+      createHmac: jest.fn<() => Promise<CreateHmacResult>>().mockResolvedValue({
+        hmac: [1, 2, 3, 4, 5]
+      })
+    }))
+  }
+})
+
+// ---------------------------------------------------------------------------
+// MockMessageBus
+// ---------------------------------------------------------------------------
+/**
+ * Stores messages per (recipient, messageBox) pair in memory.
+ * Provides send / list / ack helpers that the wired client delegates to.
+ */
+class MockMessageBus {
+  private counter = 0
+  // key: `${recipient}::${messageBox}`
+  private readonly store = new Map<string, PeerMessage[]>()
+
+  private key (recipient: string, messageBox: string): string {
+    return `${recipient}::${messageBox}`
+  }
+
+  send (params: { recipient: string, messageBox: string, body: string, sender: string }): { status: string, messageId: string } {
+    const { recipient, messageBox, body, sender } = params
+    const k = this.key(recipient, messageBox)
+    const messageId = `msg-${++this.counter}`
+    const now = new Date().toISOString()
+    const msg: PeerMessage = { messageId, sender, body, created_at: now, updated_at: now }
+    const existing = this.store.get(k)
+    if (existing != null) {
+      existing.push(msg)
+    } else {
+      this.store.set(k, [msg])
+    }
+    return { status: 'success', messageId }
+  }
+
+  list (recipient: string, messageBox: string): PeerMessage[] {
+    return this.store.get(this.key(recipient, messageBox)) ?? []
+  }
+
+  ack (recipient: string, messageBox: string, messageIds: string[]): void {
+    const k = this.key(recipient, messageBox)
+    const msgs = this.store.get(k)
+    if (msgs == null) return
+    const remaining = msgs.filter(m => !messageIds.includes(m.messageId))
+    this.store.set(k, remaining)
+  }
+
+  /** Convenience: clear everything */
+  reset (): void {
+    this.store.clear()
+    this.counter = 0
+  }
+}
+
+// ---------------------------------------------------------------------------
+// createWiredClient
+// ---------------------------------------------------------------------------
+/**
+ * Creates a PeerPayClient whose sendMessage, listMessages, acknowledgeMessage,
+ * and getIdentityKey are wired to the provided MockMessageBus instance.
+ *
+ * The identityKey is the "address" used as recipient/sender for messages
+ * sent through the bus.
+ *
+ * sendPayment is mocked to be a no-op so tests that call fulfillPaymentRequest
+ * don't need a real wallet.
+ */
+function createWiredClient (params: {
+  bus: MockMessageBus
+  identityKey: string
+  walletClient: jest.Mocked<WalletClient>
+}): PeerPayClient {
+  const { bus, identityKey, walletClient } = params
+
+  const client = new PeerPayClient({
+    messageBoxHost: 'https://messagebox.babbage.systems',
+    walletClient
+  })
+
+  // Wire getIdentityKey
+  jest.spyOn(client, 'getIdentityKey').mockResolvedValue(identityKey)
+
+  // Wire sendMessage: route to the bus using the current client identity as sender
+  jest.spyOn(client, 'sendMessage').mockImplementation(async (sendParams: any) => {
+    const body = typeof sendParams.body === 'string' ? sendParams.body : JSON.stringify(sendParams.body)
+    return bus.send({
+      recipient: sendParams.recipient,
+      messageBox: sendParams.messageBox,
+      body,
+      sender: identityKey
+    })
+  })
+
+  // Wire listMessages: retrieve from bus for this identity as recipient
+  jest.spyOn(client, 'listMessages').mockImplementation(async (listParams: any) => {
+    return bus.list(identityKey, listParams.messageBox)
+  })
+
+  // Wire acknowledgeMessage: remove messages from bus
+  // We need to know which messageBox to remove from — scan all boxes for this recipient
+  jest.spyOn(client, 'acknowledgeMessage').mockImplementation(async (ackParams: any) => {
+    const { messageIds } = ackParams
+    // Attempt to ack from all known messageBoxes
+    for (const mb of [PAYMENT_REQUESTS_MESSAGEBOX, PAYMENT_REQUEST_RESPONSES_MESSAGEBOX, STANDARD_PAYMENT_MESSAGEBOX]) {
+      bus.ack(identityKey, mb, messageIds)
+    }
+    return 'acknowledged'
+  })
+
+  // Mock sendPayment to be a no-op (avoids needing real wallet for tx creation)
+  jest.spyOn(client, 'sendPayment').mockResolvedValue(undefined)
+
+  return client
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('PeerPayClient — Integration: payment request flow', () => {
+  let bus: MockMessageBus
+  let mockWalletRequester: jest.Mocked<WalletClient>
+  let mockWalletPayer: jest.Mocked<WalletClient>
+  const REQUESTER_KEY = PrivateKey.fromRandom().toPublicKey().toString()
+  const PAYER_KEY = PrivateKey.fromRandom().toPublicKey().toString()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    bus = new MockMessageBus()
+
+    mockWalletRequester = new WalletClient() as jest.Mocked<WalletClient>
+    mockWalletRequester.getPublicKey.mockResolvedValue({ publicKey: REQUESTER_KEY })
+    mockWalletRequester.createHmac = jest.fn<() => Promise<CreateHmacResult>>().mockResolvedValue({ hmac: [1, 2, 3, 4, 5] })
+
+    mockWalletPayer = new WalletClient() as jest.Mocked<WalletClient>
+    mockWalletPayer.getPublicKey.mockResolvedValue({ publicKey: PAYER_KEY })
+    mockWalletPayer.createHmac = jest.fn<() => Promise<CreateHmacResult>>().mockResolvedValue({ hmac: [1, 2, 3, 4, 5] })
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 1: Full round-trip — request → fulfill → requester sees paid response
+  // -------------------------------------------------------------------------
+  it('Test 1: full round-trip: request → fulfill → requester sees paid response', async () => {
+    const requester = createWiredClient({ bus, identityKey: REQUESTER_KEY, walletClient: mockWalletRequester })
+    const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
+
+    // Requester sends a payment request to payer
+    const { requestId } = await requester.requestPayment({
+      recipient: PAYER_KEY,
+      amount: 5000,
+      description: 'Invoice #1',
+      expiresAt: Date.now() + 60000
+    })
+
+    expect(requestId).toBeTruthy()
+
+    // Payer lists incoming requests
+    const incoming = await payer.listIncomingPaymentRequests()
+    expect(incoming).toHaveLength(1)
+    expect(incoming[0].requestId).toBe(requestId)
+    expect(incoming[0].amount).toBe(5000)
+
+    // Payer fulfills the request
+    await payer.fulfillPaymentRequest({ request: incoming[0] })
+
+    // Requester checks for responses
+    const responses = await requester.listPaymentRequestResponses()
+    expect(responses).toHaveLength(1)
+    expect(responses[0]).toMatchObject({ requestId, status: 'paid', amountPaid: 5000 })
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 2: Full round-trip — request → decline → requester sees declined
+  // -------------------------------------------------------------------------
+  it('Test 2: full round-trip: request → decline → requester sees declined response', async () => {
+    const requester = createWiredClient({ bus, identityKey: REQUESTER_KEY, walletClient: mockWalletRequester })
+    const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
+
+    const { requestId } = await requester.requestPayment({
+      recipient: PAYER_KEY,
+      amount: 3000,
+      description: 'Invoice #2',
+      expiresAt: Date.now() + 60000
+    })
+
+    const incoming = await payer.listIncomingPaymentRequests()
+    expect(incoming).toHaveLength(1)
+
+    await payer.declinePaymentRequest({ request: incoming[0], note: 'No funds' })
+
+    const responses = await requester.listPaymentRequestResponses()
+    expect(responses).toHaveLength(1)
+    expect(responses[0]).toMatchObject({ requestId, status: 'declined', note: 'No funds' })
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 3: Request → cancel → payer no longer sees the request
+  // -------------------------------------------------------------------------
+  it('Test 3: request → cancel → payer no longer sees the request', async () => {
+    const requester = createWiredClient({ bus, identityKey: REQUESTER_KEY, walletClient: mockWalletRequester })
+    const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
+
+    const { requestId } = await requester.requestPayment({
+      recipient: PAYER_KEY,
+      amount: 2000,
+      description: 'Cancellable request',
+      expiresAt: Date.now() + 60000
+    })
+
+    // Confirm payer can see it before cancellation
+    const beforeCancel = await payer.listIncomingPaymentRequests()
+    expect(beforeCancel).toHaveLength(1)
+
+    // Requester cancels the request
+    await requester.cancelPaymentRequest({ recipient: PAYER_KEY, requestId })
+
+    // Payer should now see zero active requests (the cancel message causes filtering)
+    const afterCancel = await payer.listIncomingPaymentRequests()
+    expect(afterCancel).toHaveLength(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 4: Expired request is filtered out automatically
+  // -------------------------------------------------------------------------
+  it('Test 4: expired request is filtered out automatically', async () => {
+    const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
+
+    // Inject an already-expired request directly onto the bus (expiresAt in the past)
+    const expiredBody = JSON.stringify({
+      requestId: 'expired-req-1',
+      amount: 4000,
+      description: 'Already expired',
+      expiresAt: Date.now() - 10000, // in the past
+      senderIdentityKey: REQUESTER_KEY
+    })
+    bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: expiredBody, sender: REQUESTER_KEY })
+
+    // Also inject a valid request so the filter has something to keep
+    const validBody = JSON.stringify({
+      requestId: 'valid-req-1',
+      amount: 4000,
+      description: 'Still valid',
+      expiresAt: Date.now() + 60000,
+      senderIdentityKey: REQUESTER_KEY
+    })
+    bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: validBody, sender: REQUESTER_KEY })
+
+    const requests = await payer.listIncomingPaymentRequests()
+    expect(requests).toHaveLength(1)
+    expect(requests[0].requestId).toBe('valid-req-1')
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 5: Modified amount — payer pays a different amount
+  // -------------------------------------------------------------------------
+  it('Test 5: payer fulfills with a modified amount', async () => {
+    const requester = createWiredClient({ bus, identityKey: REQUESTER_KEY, walletClient: mockWalletRequester })
+    const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
+
+    const { requestId } = await requester.requestPayment({
+      recipient: PAYER_KEY,
+      amount: 5000,
+      description: 'Flexible request',
+      expiresAt: Date.now() + 60000
+    })
+
+    const incoming = await payer.listIncomingPaymentRequests()
+    expect(incoming).toHaveLength(1)
+
+    // Pay a different amount with a note
+    await payer.fulfillPaymentRequest({ request: incoming[0], amount: 4500, note: 'Partial payment' })
+
+    const responses = await requester.listPaymentRequestResponses()
+    expect(responses).toHaveLength(1)
+    expect(responses[0]).toMatchObject({
+      requestId,
+      status: 'paid',
+      amountPaid: 4500,
+      note: 'Partial payment'
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 6: Requests below minAmount are auto-acknowledged and excluded
+  // -------------------------------------------------------------------------
+  it('Test 6: requests below minAmount are auto-acknowledged and excluded', async () => {
+    const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
+
+    // Inject a request below the minAmount threshold
+    const smallBody = JSON.stringify({
+      requestId: 'req-small',
+      amount: 100, // below minAmount of 1000
+      description: 'Too small',
+      expiresAt: Date.now() + 60000,
+      senderIdentityKey: REQUESTER_KEY
+    })
+    bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: smallBody, sender: REQUESTER_KEY })
+
+    // Inject a valid request that passes the filter
+    const okBody = JSON.stringify({
+      requestId: 'req-ok',
+      amount: 5000,
+      description: 'Just right',
+      expiresAt: Date.now() + 60000,
+      senderIdentityKey: REQUESTER_KEY
+    })
+    bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: okBody, sender: REQUESTER_KEY })
+
+    const requests = await payer.listIncomingPaymentRequests(undefined, { minAmount: 1000, maxAmount: 10000 })
+    expect(requests).toHaveLength(1)
+    expect(requests[0].requestId).toBe('req-ok')
+
+    // The small request should have been auto-acknowledged (removed from bus)
+    const remaining = bus.list(PAYER_KEY, PAYMENT_REQUESTS_MESSAGEBOX)
+    const remainingIds = remaining.map(m => {
+      const b = JSON.parse(m.body as string)
+      return b.requestId
+    })
+    expect(remainingIds).not.toContain('req-small')
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 7: Requests above maxAmount are auto-acknowledged and excluded
+  // -------------------------------------------------------------------------
+  it('Test 7: requests above maxAmount are auto-acknowledged and excluded', async () => {
+    const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
+
+    // Inject a request above the maxAmount threshold
+    const largeBody = JSON.stringify({
+      requestId: 'req-large',
+      amount: 99999, // above maxAmount of 10000
+      description: 'Too large',
+      expiresAt: Date.now() + 60000,
+      senderIdentityKey: REQUESTER_KEY
+    })
+    bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: largeBody, sender: REQUESTER_KEY })
+
+    // Inject a valid request that passes the filter
+    const okBody = JSON.stringify({
+      requestId: 'req-ok-2',
+      amount: 5000,
+      description: 'Just right',
+      expiresAt: Date.now() + 60000,
+      senderIdentityKey: REQUESTER_KEY
+    })
+    bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: okBody, sender: REQUESTER_KEY })
+
+    const requests = await payer.listIncomingPaymentRequests(undefined, { minAmount: 1000, maxAmount: 10000 })
+    expect(requests).toHaveLength(1)
+    expect(requests[0].requestId).toBe('req-ok-2')
+
+    // The large request should have been auto-acknowledged (removed from bus)
+    const remaining = bus.list(PAYER_KEY, PAYMENT_REQUESTS_MESSAGEBOX)
+    const remainingIds = remaining.map(m => {
+      const b = JSON.parse(m.body as string)
+      return b.requestId
+    })
+    expect(remainingIds).not.toContain('req-large')
+  })
+})

--- a/src/__tests/PeerPayClientRequestIntegration.test.ts
+++ b/src/__tests/PeerPayClientRequestIntegration.test.ts
@@ -160,10 +160,12 @@ describe('PeerPayClient — Integration: payment request flow', () => {
     mockWalletRequester = new WalletClient() as jest.Mocked<WalletClient>
     mockWalletRequester.getPublicKey.mockResolvedValue({ publicKey: REQUESTER_KEY })
     mockWalletRequester.createHmac = jest.fn<() => Promise<CreateHmacResult>>().mockResolvedValue({ hmac: [1, 2, 3, 4, 5] })
+    mockWalletRequester.verifyHmac = jest.fn().mockResolvedValue({ valid: true })
 
     mockWalletPayer = new WalletClient() as jest.Mocked<WalletClient>
     mockWalletPayer.getPublicKey.mockResolvedValue({ publicKey: PAYER_KEY })
     mockWalletPayer.createHmac = jest.fn<() => Promise<CreateHmacResult>>().mockResolvedValue({ hmac: [1, 2, 3, 4, 5] })
+    mockWalletPayer.verifyHmac = jest.fn().mockResolvedValue({ valid: true })
   })
 
   // -------------------------------------------------------------------------
@@ -229,7 +231,7 @@ describe('PeerPayClient — Integration: payment request flow', () => {
     const requester = createWiredClient({ bus, identityKey: REQUESTER_KEY, walletClient: mockWalletRequester })
     const payer = createWiredClient({ bus, identityKey: PAYER_KEY, walletClient: mockWalletPayer })
 
-    const { requestId } = await requester.requestPayment({
+    const { requestId, requestProof } = await requester.requestPayment({
       recipient: PAYER_KEY,
       amount: 2000,
       description: 'Cancellable request',
@@ -241,7 +243,7 @@ describe('PeerPayClient — Integration: payment request flow', () => {
     expect(beforeCancel).toHaveLength(1)
 
     // Requester cancels the request
-    await requester.cancelPaymentRequest({ recipient: PAYER_KEY, requestId })
+    await requester.cancelPaymentRequest({ recipient: PAYER_KEY, requestId, requestProof })
 
     // Payer should now see zero active requests (the cancel message causes filtering)
     const afterCancel = await payer.listIncomingPaymentRequests()
@@ -260,7 +262,8 @@ describe('PeerPayClient — Integration: payment request flow', () => {
       amount: 4000,
       description: 'Already expired',
       expiresAt: Date.now() - 10000, // in the past
-      senderIdentityKey: REQUESTER_KEY
+      senderIdentityKey: REQUESTER_KEY,
+      requestProof: 'mock-proof'
     })
     bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: expiredBody, sender: REQUESTER_KEY })
 
@@ -270,7 +273,8 @@ describe('PeerPayClient — Integration: payment request flow', () => {
       amount: 4000,
       description: 'Still valid',
       expiresAt: Date.now() + 60000,
-      senderIdentityKey: REQUESTER_KEY
+      senderIdentityKey: REQUESTER_KEY,
+      requestProof: 'mock-proof'
     })
     bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: validBody, sender: REQUESTER_KEY })
 
@@ -291,7 +295,8 @@ describe('PeerPayClient — Integration: payment request flow', () => {
       amount: 100, // below minAmount of 1000
       description: 'Too small',
       expiresAt: Date.now() + 60000,
-      senderIdentityKey: REQUESTER_KEY
+      senderIdentityKey: REQUESTER_KEY,
+      requestProof: 'mock-proof'
     })
     bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: smallBody, sender: REQUESTER_KEY })
 
@@ -301,7 +306,8 @@ describe('PeerPayClient — Integration: payment request flow', () => {
       amount: 5000,
       description: 'Just right',
       expiresAt: Date.now() + 60000,
-      senderIdentityKey: REQUESTER_KEY
+      senderIdentityKey: REQUESTER_KEY,
+      requestProof: 'mock-proof'
     })
     bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: okBody, sender: REQUESTER_KEY })
 
@@ -330,7 +336,8 @@ describe('PeerPayClient — Integration: payment request flow', () => {
       amount: 99999, // above maxAmount of 10000
       description: 'Too large',
       expiresAt: Date.now() + 60000,
-      senderIdentityKey: REQUESTER_KEY
+      senderIdentityKey: REQUESTER_KEY,
+      requestProof: 'mock-proof'
     })
     bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: largeBody, sender: REQUESTER_KEY })
 
@@ -340,7 +347,8 @@ describe('PeerPayClient — Integration: payment request flow', () => {
       amount: 5000,
       description: 'Just right',
       expiresAt: Date.now() + 60000,
-      senderIdentityKey: REQUESTER_KEY
+      senderIdentityKey: REQUESTER_KEY,
+      requestProof: 'mock-proof'
     })
     bus.send({ recipient: PAYER_KEY, messageBox: PAYMENT_REQUESTS_MESSAGEBOX, body: okBody, sender: REQUESTER_KEY })
 

--- a/src/__tests/PeerPayClientUnit.test.ts
+++ b/src/__tests/PeerPayClientUnit.test.ts
@@ -242,4 +242,75 @@ describe('PeerPayClient Unit Tests', () => {
       expect(payments[1].token.amount).toBe(9)
     })
   })
+
+  // Test: requestPayment
+  describe('requestPayment', () => {
+    it('sends payment request message to payment_requests box with correct body fields', async () => {
+      jest.spyOn(peerPayClient, 'getIdentityKey').mockResolvedValue('myIdentityKey')
+      const sendMessageSpy = jest.spyOn(peerPayClient, 'sendMessage').mockResolvedValue({
+        status: 'success',
+        messageId: 'mockedMessageId'
+      })
+
+      const result = await peerPayClient.requestPayment({
+        recipient: 'recipientKey',
+        amount: 1000,
+        description: 'Please pay me',
+        expiresAt: Date.now() + 60000
+      })
+
+      expect(result).toHaveProperty('requestId')
+      expect(typeof result.requestId).toBe('string')
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipient: 'recipientKey',
+          messageBox: 'payment_requests',
+          body: expect.stringContaining('"amount":1000')
+        }),
+        undefined
+      )
+
+      const sentBody = JSON.parse((sendMessageSpy.mock.calls[0][0] as any).body)
+      expect(sentBody).toHaveProperty('requestId')
+      expect(sentBody).toHaveProperty('amount', 1000)
+      expect(sentBody).toHaveProperty('description', 'Please pay me')
+      expect(sentBody).toHaveProperty('senderIdentityKey', 'myIdentityKey')
+    })
+
+    it('throws if amount <= 0', async () => {
+      await expect(peerPayClient.requestPayment({
+        recipient: 'recipientKey',
+        amount: 0,
+        description: 'Bad request',
+        expiresAt: Date.now() + 60000
+      })).rejects.toThrow()
+    })
+  })
+
+  // Test: cancelPaymentRequest
+  describe('cancelPaymentRequest', () => {
+    it('sends cancellation message with same requestId and cancelled: true', async () => {
+      const sendMessageSpy = jest.spyOn(peerPayClient, 'sendMessage').mockResolvedValue({
+        status: 'success',
+        messageId: 'mockedMessageId'
+      })
+
+      await peerPayClient.cancelPaymentRequest({
+        recipient: 'recipientKey',
+        requestId: 'existing-request-id'
+      })
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipient: 'recipientKey',
+          messageBox: 'payment_requests'
+        }),
+        undefined
+      )
+
+      const sentBody = JSON.parse((sendMessageSpy.mock.calls[0][0] as any).body)
+      expect(sentBody).toHaveProperty('requestId', 'existing-request-id')
+      expect(sentBody).toHaveProperty('cancelled', true)
+    })
+  })
 })

--- a/src/__tests/PeerPayClientUnit.test.ts
+++ b/src/__tests/PeerPayClientUnit.test.ts
@@ -515,6 +515,96 @@ describe('PeerPayClient Unit Tests', () => {
     })
   })
 
+  // Test: listPaymentRequestResponses
+  describe('listPaymentRequestResponses', () => {
+    it('returns parsed responses from payment_request_responses box', async () => {
+      jest.spyOn(peerPayClient, 'listMessages').mockResolvedValue([
+        {
+          messageId: 'resp-1',
+          sender: 'payer1',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({ requestId: 'req-1', status: 'paid', amountPaid: 5000 })
+        },
+        {
+          messageId: 'resp-2',
+          sender: 'payer2',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({ requestId: 'req-2', status: 'declined', note: 'No funds' })
+        }
+      ])
+
+      const responses = await peerPayClient.listPaymentRequestResponses()
+
+      expect(responses).toHaveLength(2)
+      expect(responses[0]).toMatchObject({ requestId: 'req-1', status: 'paid', amountPaid: 5000 })
+      expect(responses[1]).toMatchObject({ requestId: 'req-2', status: 'declined', note: 'No funds' })
+    })
+  })
+
+  // Test: listenForLivePaymentRequests
+  describe('listenForLivePaymentRequests', () => {
+    it('calls listenForLiveMessages on payment_requests box and converts messages to IncomingPaymentRequest', async () => {
+      const listenSpy = jest.spyOn(peerPayClient, 'listenForLiveMessages').mockResolvedValue(undefined)
+      const onRequest = jest.fn()
+
+      await peerPayClient.listenForLivePaymentRequests({ onRequest })
+
+      expect(listenSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ messageBox: 'payment_requests' })
+      )
+
+      // Simulate a message arriving by calling the onMessage callback
+      const { onMessage } = (listenSpy.mock.calls[0][0] as any)
+      onMessage({
+        messageId: 'live-msg-1',
+        sender: 'sender1',
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+        body: JSON.stringify({
+          requestId: 'req-live-1',
+          amount: 3000,
+          description: 'Live request',
+          expiresAt: Date.now() + 60000,
+          senderIdentityKey: 'sender1'
+        })
+      })
+
+      expect(onRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ messageId: 'live-msg-1', requestId: 'req-live-1', amount: 3000 })
+      )
+    })
+  })
+
+  // Test: listenForLivePaymentRequestResponses
+  describe('listenForLivePaymentRequestResponses', () => {
+    it('calls listenForLiveMessages on payment_request_responses box and parses responses', async () => {
+      const listenSpy = jest.spyOn(peerPayClient, 'listenForLiveMessages').mockResolvedValue(undefined)
+      const onResponse = jest.fn()
+
+      await peerPayClient.listenForLivePaymentRequestResponses({ onResponse })
+
+      expect(listenSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ messageBox: 'payment_request_responses' })
+      )
+
+      // Simulate a message arriving
+      const { onMessage } = (listenSpy.mock.calls[0][0] as any)
+      onMessage({
+        messageId: 'live-resp-1',
+        sender: 'payer1',
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+        body: JSON.stringify({ requestId: 'req-1', status: 'paid', amountPaid: 5000 })
+      })
+
+      expect(onResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: 'req-1', status: 'paid', amountPaid: 5000 })
+      )
+    })
+  })
+
   // Test: requestPayment
   describe('requestPayment', () => {
     it('sends payment request message to payment_requests box with correct body fields', async () => {

--- a/src/__tests/PeerPayClientUnit.test.ts
+++ b/src/__tests/PeerPayClientUnit.test.ts
@@ -243,6 +243,183 @@ describe('PeerPayClient Unit Tests', () => {
     })
   })
 
+  // Test: listIncomingPaymentRequests
+  describe('listIncomingPaymentRequests', () => {
+    const futureExpiry = Date.now() + 60000
+    const pastExpiry = Date.now() - 60000
+
+    it('returns parsed request messages from payment_requests box', async () => {
+      jest.spyOn(peerPayClient, 'listMessages').mockResolvedValue([
+        {
+          messageId: 'msg1',
+          sender: 'sender1',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({
+            requestId: 'req1',
+            amount: 5000,
+            description: 'Test request',
+            expiresAt: futureExpiry,
+            senderIdentityKey: 'sender1'
+          })
+        }
+      ])
+      jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
+
+      const requests = await peerPayClient.listIncomingPaymentRequests()
+
+      expect(requests).toHaveLength(1)
+      expect(requests[0]).toMatchObject({
+        messageId: 'msg1',
+        sender: 'sender1',
+        requestId: 'req1',
+        amount: 5000,
+        description: 'Test request'
+      })
+    })
+
+    it('filters expired requests and acknowledges them', async () => {
+      jest.spyOn(peerPayClient, 'listMessages').mockResolvedValue([
+        {
+          messageId: 'expired-msg',
+          sender: 'sender1',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({
+            requestId: 'req-expired',
+            amount: 5000,
+            description: 'Expired request',
+            expiresAt: pastExpiry,
+            senderIdentityKey: 'sender1'
+          })
+        },
+        {
+          messageId: 'active-msg',
+          sender: 'sender2',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({
+            requestId: 'req-active',
+            amount: 3000,
+            description: 'Active request',
+            expiresAt: futureExpiry,
+            senderIdentityKey: 'sender2'
+          })
+        }
+      ])
+      const ackSpy = jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
+
+      const requests = await peerPayClient.listIncomingPaymentRequests()
+
+      expect(requests).toHaveLength(1)
+      expect(requests[0].requestId).toBe('req-active')
+      expect(ackSpy).toHaveBeenCalledWith({ messageIds: ['expired-msg'] })
+    })
+
+    it('filters cancelled requests and acknowledges both original and cancel messages', async () => {
+      jest.spyOn(peerPayClient, 'listMessages').mockResolvedValue([
+        {
+          messageId: 'original-msg',
+          sender: 'sender1',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({
+            requestId: 'req-cancel',
+            amount: 5000,
+            description: 'To be cancelled',
+            expiresAt: futureExpiry,
+            senderIdentityKey: 'sender1'
+          })
+        },
+        {
+          messageId: 'cancel-msg',
+          sender: 'sender1',
+          created_at: '2025-01-01T00:01:00Z',
+          updated_at: '2025-01-01T00:01:00Z',
+          body: JSON.stringify({
+            requestId: 'req-cancel',
+            amount: 0,
+            description: '',
+            expiresAt: 0,
+            senderIdentityKey: '',
+            cancelled: true
+          })
+        },
+        {
+          messageId: 'other-msg',
+          sender: 'sender2',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({
+            requestId: 'req-other',
+            amount: 2000,
+            description: 'Other request',
+            expiresAt: futureExpiry,
+            senderIdentityKey: 'sender2'
+          })
+        }
+      ])
+      const ackSpy = jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
+
+      const requests = await peerPayClient.listIncomingPaymentRequests()
+
+      expect(requests).toHaveLength(1)
+      expect(requests[0].requestId).toBe('req-other')
+      expect(ackSpy).toHaveBeenCalledWith({ messageIds: expect.arrayContaining(['original-msg', 'cancel-msg']) })
+    })
+
+    it('filters out requests below minAmount and above maxAmount, acknowledges them', async () => {
+      jest.spyOn(peerPayClient, 'listMessages').mockResolvedValue([
+        {
+          messageId: 'too-small',
+          sender: 'sender1',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({
+            requestId: 'req-small',
+            amount: 100,
+            description: 'Too small',
+            expiresAt: futureExpiry,
+            senderIdentityKey: 'sender1'
+          })
+        },
+        {
+          messageId: 'too-large',
+          sender: 'sender2',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({
+            requestId: 'req-large',
+            amount: 99999,
+            description: 'Too large',
+            expiresAt: futureExpiry,
+            senderIdentityKey: 'sender2'
+          })
+        },
+        {
+          messageId: 'just-right',
+          sender: 'sender3',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({
+            requestId: 'req-ok',
+            amount: 5000,
+            description: 'Just right',
+            expiresAt: futureExpiry,
+            senderIdentityKey: 'sender3'
+          })
+        }
+      ])
+      const ackSpy = jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
+
+      const requests = await peerPayClient.listIncomingPaymentRequests(undefined, { minAmount: 1000, maxAmount: 10000 })
+
+      expect(requests).toHaveLength(1)
+      expect(requests[0].requestId).toBe('req-ok')
+      expect(ackSpy).toHaveBeenCalledWith({ messageIds: expect.arrayContaining(['too-small', 'too-large']) })
+    })
+  })
+
   // Test: requestPayment
   describe('requestPayment', () => {
     it('sends payment request message to payment_requests box with correct body fields', async () => {

--- a/src/__tests/PeerPayClientUnit.test.ts
+++ b/src/__tests/PeerPayClientUnit.test.ts
@@ -368,6 +368,97 @@ describe('PeerPayClient Unit Tests', () => {
       expect(ackSpy).toHaveBeenCalledWith({ messageIds: expect.arrayContaining(['original-msg', 'cancel-msg']) })
     })
 
+    it('discards malformed messages (invalid JSON) and acknowledges them', async () => {
+      jest.spyOn(peerPayClient, 'listMessages').mockResolvedValue([
+        {
+          messageId: 'bad-msg',
+          sender: 'sender1',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: 'NOT VALID JSON {{{}'
+        },
+        {
+          messageId: 'good-msg',
+          sender: 'sender2',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({
+            requestId: 'req-good',
+            amount: 5000,
+            description: 'Valid request',
+            expiresAt: Date.now() + 60000,
+            senderIdentityKey: 'sender2'
+          })
+        }
+      ])
+      const ackSpy = jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
+
+      const requests = await peerPayClient.listIncomingPaymentRequests()
+
+      expect(requests).toHaveLength(1)
+      expect(requests[0].requestId).toBe('req-good')
+      expect(ackSpy).toHaveBeenCalledWith(expect.objectContaining({
+        messageIds: expect.arrayContaining(['bad-msg'])
+      }))
+    })
+
+    it('discards messages with missing required fields and acknowledges them', async () => {
+      jest.spyOn(peerPayClient, 'listMessages').mockResolvedValue([
+        {
+          messageId: 'incomplete-msg',
+          sender: 'sender1',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({ requestId: 'req-incomplete' })
+        }
+      ])
+      const ackSpy = jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
+
+      const requests = await peerPayClient.listIncomingPaymentRequests()
+
+      expect(requests).toHaveLength(0)
+      expect(ackSpy).toHaveBeenCalledWith(expect.objectContaining({
+        messageIds: expect.arrayContaining(['incomplete-msg'])
+      }))
+    })
+
+    it('only cancels requests from the same sender', async () => {
+      const futureExpiry = Date.now() + 60000
+      jest.spyOn(peerPayClient, 'listMessages').mockResolvedValue([
+        {
+          messageId: 'original-msg',
+          sender: 'sender1',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          body: JSON.stringify({
+            requestId: 'req-1',
+            amount: 5000,
+            description: 'Real request',
+            expiresAt: futureExpiry,
+            senderIdentityKey: 'sender1'
+          })
+        },
+        {
+          messageId: 'spoofed-cancel',
+          sender: 'attacker',
+          created_at: '2025-01-01T00:01:00Z',
+          updated_at: '2025-01-01T00:01:00Z',
+          body: JSON.stringify({
+            requestId: 'req-1',
+            senderIdentityKey: 'attacker',
+            cancelled: true
+          })
+        }
+      ])
+      jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
+
+      const requests = await peerPayClient.listIncomingPaymentRequests()
+
+      // The request should NOT be cancelled because the cancel came from a different sender
+      expect(requests).toHaveLength(1)
+      expect(requests[0].requestId).toBe('req-1')
+    })
+
     it('filters out requests below minAmount and above maxAmount, acknowledges them', async () => {
       jest.spyOn(peerPayClient, 'listMessages').mockResolvedValue([
         {

--- a/src/__tests/PeerPayClientUnit.test.ts
+++ b/src/__tests/PeerPayClientUnit.test.ts
@@ -605,6 +605,66 @@ describe('PeerPayClient Unit Tests', () => {
     })
   })
 
+  // Test: allowPaymentRequestsFrom
+  describe('allowPaymentRequestsFrom', () => {
+    it('calls setMessageBoxPermission with messageBox=payment_requests and recipientFee=0', async () => {
+      const setPermSpy = jest.spyOn(peerPayClient, 'setMessageBoxPermission').mockResolvedValue(undefined)
+
+      await peerPayClient.allowPaymentRequestsFrom({ identityKey: 'trustedKey' })
+
+      expect(setPermSpy).toHaveBeenCalledWith({
+        messageBox: 'payment_requests',
+        sender: 'trustedKey',
+        recipientFee: 0
+      })
+    })
+  })
+
+  // Test: blockPaymentRequestsFrom
+  describe('blockPaymentRequestsFrom', () => {
+    it('calls setMessageBoxPermission with recipientFee=-1', async () => {
+      const setPermSpy = jest.spyOn(peerPayClient, 'setMessageBoxPermission').mockResolvedValue(undefined)
+
+      await peerPayClient.blockPaymentRequestsFrom({ identityKey: 'blockedKey' })
+
+      expect(setPermSpy).toHaveBeenCalledWith({
+        messageBox: 'payment_requests',
+        sender: 'blockedKey',
+        recipientFee: -1
+      })
+    })
+  })
+
+  // Test: listPaymentRequestPermissions
+  describe('listPaymentRequestPermissions', () => {
+    it('calls listMessageBoxPermissions and maps to { identityKey, allowed } array', async () => {
+      jest.spyOn(peerPayClient, 'listMessageBoxPermissions').mockResolvedValue([
+        {
+          sender: 'key1',
+          messageBox: 'payment_requests',
+          recipientFee: 0,
+          status: 'always_allow',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z'
+        },
+        {
+          sender: 'key2',
+          messageBox: 'payment_requests',
+          recipientFee: -1,
+          status: 'blocked',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z'
+        }
+      ])
+
+      const permissions = await peerPayClient.listPaymentRequestPermissions()
+
+      expect(permissions).toHaveLength(2)
+      expect(permissions[0]).toEqual({ identityKey: 'key1', allowed: true })
+      expect(permissions[1]).toEqual({ identityKey: 'key2', allowed: false })
+    })
+  })
+
   // Test: requestPayment
   describe('requestPayment', () => {
     it('sends payment request message to payment_requests box with correct body fields', async () => {

--- a/src/__tests/PeerPayClientUnit.test.ts
+++ b/src/__tests/PeerPayClientUnit.test.ts
@@ -36,7 +36,8 @@ jest.mock('@bsv/sdk', () => {
       internalizeAction: jest.fn(),
       createHmac: jest.fn<() => Promise<CreateHmacResult>>().mockResolvedValue({
         hmac: [1, 2, 3, 4, 5]
-      })
+      }),
+      verifyHmac: jest.fn().mockResolvedValue({ valid: true })
     }))
   }
 })
@@ -260,7 +261,8 @@ describe('PeerPayClient Unit Tests', () => {
             amount: 5000,
             description: 'Test request',
             expiresAt: futureExpiry,
-            senderIdentityKey: 'sender1'
+            senderIdentityKey: 'sender1',
+            requestProof: 'abcd1234'
           })
         }
       ])
@@ -290,7 +292,8 @@ describe('PeerPayClient Unit Tests', () => {
             amount: 5000,
             description: 'Expired request',
             expiresAt: pastExpiry,
-            senderIdentityKey: 'sender1'
+            senderIdentityKey: 'sender1',
+            requestProof: 'abcd1234'
           })
         },
         {
@@ -303,7 +306,8 @@ describe('PeerPayClient Unit Tests', () => {
             amount: 3000,
             description: 'Active request',
             expiresAt: futureExpiry,
-            senderIdentityKey: 'sender2'
+            senderIdentityKey: 'sender2',
+            requestProof: 'abcd1234'
           })
         }
       ])
@@ -328,7 +332,8 @@ describe('PeerPayClient Unit Tests', () => {
             amount: 5000,
             description: 'To be cancelled',
             expiresAt: futureExpiry,
-            senderIdentityKey: 'sender1'
+            senderIdentityKey: 'sender1',
+            requestProof: 'abcd1234'
           })
         },
         {
@@ -338,11 +343,9 @@ describe('PeerPayClient Unit Tests', () => {
           updated_at: '2025-01-01T00:01:00Z',
           body: JSON.stringify({
             requestId: 'req-cancel',
-            amount: 0,
-            description: '',
-            expiresAt: 0,
-            senderIdentityKey: '',
-            cancelled: true
+            senderIdentityKey: 'sender1',
+            cancelled: true,
+            requestProof: 'abcd1234'
           })
         },
         {
@@ -355,7 +358,8 @@ describe('PeerPayClient Unit Tests', () => {
             amount: 2000,
             description: 'Other request',
             expiresAt: futureExpiry,
-            senderIdentityKey: 'sender2'
+            senderIdentityKey: 'sender2',
+            requestProof: 'abcd1234'
           })
         }
       ])
@@ -387,7 +391,8 @@ describe('PeerPayClient Unit Tests', () => {
             amount: 5000,
             description: 'Valid request',
             expiresAt: Date.now() + 60000,
-            senderIdentityKey: 'sender2'
+            senderIdentityKey: 'sender2',
+            requestProof: 'abcd1234'
           })
         }
       ])
@@ -435,7 +440,8 @@ describe('PeerPayClient Unit Tests', () => {
             amount: 5000,
             description: 'Real request',
             expiresAt: futureExpiry,
-            senderIdentityKey: 'sender1'
+            senderIdentityKey: 'sender1',
+            requestProof: 'abcd1234'
           })
         },
         {
@@ -446,7 +452,8 @@ describe('PeerPayClient Unit Tests', () => {
           body: JSON.stringify({
             requestId: 'req-1',
             senderIdentityKey: 'attacker',
-            cancelled: true
+            cancelled: true,
+            requestProof: 'abcd1234'
           })
         }
       ])
@@ -471,7 +478,8 @@ describe('PeerPayClient Unit Tests', () => {
             amount: 100,
             description: 'Too small',
             expiresAt: futureExpiry,
-            senderIdentityKey: 'sender1'
+            senderIdentityKey: 'sender1',
+            requestProof: 'abcd1234'
           })
         },
         {
@@ -484,7 +492,8 @@ describe('PeerPayClient Unit Tests', () => {
             amount: 99999,
             description: 'Too large',
             expiresAt: futureExpiry,
-            senderIdentityKey: 'sender2'
+            senderIdentityKey: 'sender2',
+            requestProof: 'abcd1234'
           })
         },
         {
@@ -497,7 +506,8 @@ describe('PeerPayClient Unit Tests', () => {
             amount: 5000,
             description: 'Just right',
             expiresAt: futureExpiry,
-            senderIdentityKey: 'sender3'
+            senderIdentityKey: 'sender3',
+            requestProof: 'abcd1234'
           })
         }
       ])
@@ -645,7 +655,8 @@ describe('PeerPayClient Unit Tests', () => {
           amount: 3000,
           description: 'Live request',
           expiresAt: Date.now() + 60000,
-          senderIdentityKey: 'sender1'
+          senderIdentityKey: 'sender1',
+          requestProof: 'abcd1234'
         })
       })
 
@@ -775,6 +786,11 @@ describe('PeerPayClient Unit Tests', () => {
       expect(sentBody).toHaveProperty('amount', 1000)
       expect(sentBody).toHaveProperty('description', 'Please pay me')
       expect(sentBody).toHaveProperty('senderIdentityKey', 'myIdentityKey')
+      expect(sentBody).toHaveProperty('requestProof')
+      expect(typeof sentBody.requestProof).toBe('string')
+      expect(sentBody.requestProof.length).toBeGreaterThan(0)
+
+      expect(result).toHaveProperty('requestProof')
     })
 
     it('throws if amount <= 0', async () => {
@@ -798,7 +814,8 @@ describe('PeerPayClient Unit Tests', () => {
 
       await peerPayClient.cancelPaymentRequest({
         recipient: 'recipientKey',
-        requestId: 'existing-request-id'
+        requestId: 'existing-request-id',
+        requestProof: 'original-proof-hex'
       })
 
       expect(sendMessageSpy).toHaveBeenCalledWith(
@@ -813,6 +830,7 @@ describe('PeerPayClient Unit Tests', () => {
       expect(sentBody).toEqual({
         requestId: 'existing-request-id',
         senderIdentityKey: 'myIdentityKey',
+        requestProof: 'original-proof-hex',
         cancelled: true
       })
     })

--- a/src/__tests/PeerPayClientUnit.test.ts
+++ b/src/__tests/PeerPayClientUnit.test.ts
@@ -420,6 +420,101 @@ describe('PeerPayClient Unit Tests', () => {
     })
   })
 
+  // Test: fulfillPaymentRequest
+  describe('fulfillPaymentRequest', () => {
+    const mockRequest = {
+      messageId: 'req-msg-1',
+      sender: 'senderKey',
+      requestId: 'req-id-1',
+      amount: 5000,
+      description: 'Pay for goods',
+      expiresAt: Date.now() + 60000
+    }
+
+    it('sends payment via sendPayment(), sends paid response to payment_request_responses, acknowledges original request', async () => {
+      const sendPaymentSpy = jest.spyOn(peerPayClient, 'sendPayment').mockResolvedValue(undefined)
+      const sendMessageSpy = jest.spyOn(peerPayClient, 'sendMessage').mockResolvedValue({
+        status: 'success',
+        messageId: 'resp-msg-id'
+      })
+      const ackSpy = jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
+
+      await peerPayClient.fulfillPaymentRequest({ request: mockRequest })
+
+      expect(sendPaymentSpy).toHaveBeenCalledWith(
+        { recipient: 'senderKey', amount: 5000 },
+        undefined
+      )
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipient: 'senderKey',
+          messageBox: 'payment_request_responses'
+        }),
+        undefined
+      )
+
+      const responseBody = JSON.parse((sendMessageSpy.mock.calls[0][0] as any).body)
+      expect(responseBody).toMatchObject({ requestId: 'req-id-1', status: 'paid' })
+
+      expect(ackSpy).toHaveBeenCalledWith({ messageIds: ['req-msg-1'] })
+    })
+
+    it('allows amount and note to be overridden', async () => {
+      const sendPaymentSpy = jest.spyOn(peerPayClient, 'sendPayment').mockResolvedValue(undefined)
+      const sendMessageSpy = jest.spyOn(peerPayClient, 'sendMessage').mockResolvedValue({
+        status: 'success',
+        messageId: 'resp-msg-id'
+      })
+      jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
+
+      await peerPayClient.fulfillPaymentRequest({ request: mockRequest, amount: 4500, note: 'Here you go' })
+
+      expect(sendPaymentSpy).toHaveBeenCalledWith(
+        { recipient: 'senderKey', amount: 4500 },
+        undefined
+      )
+
+      const responseBody = JSON.parse((sendMessageSpy.mock.calls[0][0] as any).body)
+      expect(responseBody).toMatchObject({ requestId: 'req-id-1', status: 'paid', amountPaid: 4500, note: 'Here you go' })
+    })
+  })
+
+  // Test: declinePaymentRequest
+  describe('declinePaymentRequest', () => {
+    const mockRequest = {
+      messageId: 'req-msg-2',
+      sender: 'senderKey2',
+      requestId: 'req-id-2',
+      amount: 3000,
+      description: 'Pay for service',
+      expiresAt: Date.now() + 60000
+    }
+
+    it('sends declined response to payment_request_responses and acknowledges request', async () => {
+      const sendMessageSpy = jest.spyOn(peerPayClient, 'sendMessage').mockResolvedValue({
+        status: 'success',
+        messageId: 'resp-msg-id'
+      })
+      const ackSpy = jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
+
+      await peerPayClient.declinePaymentRequest({ request: mockRequest, note: 'Not today' })
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipient: 'senderKey2',
+          messageBox: 'payment_request_responses'
+        }),
+        undefined
+      )
+
+      const responseBody = JSON.parse((sendMessageSpy.mock.calls[0][0] as any).body)
+      expect(responseBody).toMatchObject({ requestId: 'req-id-2', status: 'declined', note: 'Not today' })
+
+      expect(ackSpy).toHaveBeenCalledWith({ messageIds: ['req-msg-2'] })
+    })
+  })
+
   // Test: requestPayment
   describe('requestPayment', () => {
     it('sends payment request message to payment_requests box with correct body fields', async () => {

--- a/src/__tests/PeerPayClientUnit.test.ts
+++ b/src/__tests/PeerPayClientUnit.test.ts
@@ -37,7 +37,7 @@ jest.mock('@bsv/sdk', () => {
       createHmac: jest.fn<() => Promise<CreateHmacResult>>().mockResolvedValue({
         hmac: [1, 2, 3, 4, 5]
       }),
-      verifyHmac: jest.fn().mockResolvedValue({ valid: true })
+      verifyHmac: jest.fn<() => Promise<{ valid: true }>>().mockResolvedValue({ valid: true as const })
     }))
   }
 })

--- a/src/__tests/PeerPayClientUnit.test.ts
+++ b/src/__tests/PeerPayClientUnit.test.ts
@@ -431,7 +431,7 @@ describe('PeerPayClient Unit Tests', () => {
       expiresAt: Date.now() + 60000
     }
 
-    it('sends payment via sendPayment(), sends paid response to payment_request_responses, acknowledges original request', async () => {
+    it('sends payment for request.amount, sends paid response, acknowledges', async () => {
       const sendPaymentSpy = jest.spyOn(peerPayClient, 'sendPayment').mockResolvedValue(undefined)
       const sendMessageSpy = jest.spyOn(peerPayClient, 'sendMessage').mockResolvedValue({
         status: 'success',
@@ -446,37 +446,24 @@ describe('PeerPayClient Unit Tests', () => {
         undefined
       )
 
-      expect(sendMessageSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          recipient: 'senderKey',
-          messageBox: 'payment_request_responses'
-        }),
-        undefined
-      )
-
       const responseBody = JSON.parse((sendMessageSpy.mock.calls[0][0] as any).body)
-      expect(responseBody).toMatchObject({ requestId: 'req-id-1', status: 'paid' })
+      expect(responseBody).toMatchObject({ requestId: 'req-id-1', status: 'paid', amountPaid: 5000 })
 
       expect(ackSpy).toHaveBeenCalledWith({ messageIds: ['req-msg-1'] })
     })
 
-    it('allows amount and note to be overridden', async () => {
-      const sendPaymentSpy = jest.spyOn(peerPayClient, 'sendPayment').mockResolvedValue(undefined)
+    it('includes note when provided', async () => {
+      jest.spyOn(peerPayClient, 'sendPayment').mockResolvedValue(undefined)
       const sendMessageSpy = jest.spyOn(peerPayClient, 'sendMessage').mockResolvedValue({
         status: 'success',
         messageId: 'resp-msg-id'
       })
       jest.spyOn(peerPayClient, 'acknowledgeMessage').mockResolvedValue('ok')
 
-      await peerPayClient.fulfillPaymentRequest({ request: mockRequest, amount: 4500, note: 'Here you go' })
-
-      expect(sendPaymentSpy).toHaveBeenCalledWith(
-        { recipient: 'senderKey', amount: 4500 },
-        undefined
-      )
+      await peerPayClient.fulfillPaymentRequest({ request: mockRequest, note: 'Here you go' })
 
       const responseBody = JSON.parse((sendMessageSpy.mock.calls[0][0] as any).body)
-      expect(responseBody).toMatchObject({ requestId: 'req-id-1', status: 'paid', amountPaid: 4500, note: 'Here you go' })
+      expect(responseBody).toMatchObject({ note: 'Here you go' })
     })
   })
 
@@ -711,7 +698,8 @@ describe('PeerPayClient Unit Tests', () => {
 
   // Test: cancelPaymentRequest
   describe('cancelPaymentRequest', () => {
-    it('sends cancellation message with same requestId and cancelled: true', async () => {
+    it('sends cancellation message with requestId, real senderIdentityKey, and cancelled: true', async () => {
+      jest.spyOn(peerPayClient, 'getIdentityKey').mockResolvedValue('myIdentityKey')
       const sendMessageSpy = jest.spyOn(peerPayClient, 'sendMessage').mockResolvedValue({
         status: 'success',
         messageId: 'mockedMessageId'
@@ -731,8 +719,11 @@ describe('PeerPayClient Unit Tests', () => {
       )
 
       const sentBody = JSON.parse((sendMessageSpy.mock.calls[0][0] as any).body)
-      expect(sentBody).toHaveProperty('requestId', 'existing-request-id')
-      expect(sentBody).toHaveProperty('cancelled', true)
+      expect(sentBody).toEqual({
+        requestId: 'existing-request-id',
+        senderIdentityKey: 'myIdentityKey',
+        cancelled: true
+      })
     })
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,6 +209,8 @@ export interface PaymentRequestNew extends PaymentRequestBase {
   description: string
   /** Unix timestamp (ms) after which the request expires. Set by the sender. */
   expiresAt: number
+  /** HMAC proof tying this request to the sender's identity. Used to authorize cancellations. */
+  requestProof: string
   /** Omitted or false for a new payment request. */
   cancelled?: false
 }
@@ -220,6 +222,8 @@ export interface PaymentRequestNew extends PaymentRequestBase {
 export interface PaymentRequestCancellation extends PaymentRequestBase {
   /** If true, this message cancels a previously sent request with the same requestId. */
   cancelled: true
+  /** HMAC proof from the original request, proving cancellation authority. */
+  requestProof: string
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,3 +187,69 @@ export interface ListDevicesResponse {
   devices: RegisteredDevice[]
   description?: string // For error responses
 }
+
+/**
+ * Represents a payment request message sent from a requester to a payer.
+ * Carried in the 'payment_requests' message box.
+ */
+export interface PaymentRequestMessage {
+  /** Unique identifier for this request, generated via createNonce(). */
+  requestId: string
+  /** Amount in satoshis being requested. */
+  amount: number
+  /** Human-readable reason for the request. */
+  description: string
+  /** Unix timestamp (ms) after which the request expires. Set by the sender. */
+  expiresAt: number
+  /** Identity key of the requester, used for correlation on the payer's side. */
+  senderIdentityKey: string
+  /** If true, this message cancels a previously sent request with the same requestId. */
+  cancelled?: boolean
+}
+
+/**
+ * Represents a response to a payment request, sent from the payer back to the requester.
+ * Carried in the 'payment_request_responses' message box.
+ */
+export interface PaymentRequestResponse {
+  /** The requestId of the original PaymentRequestMessage this responds to. */
+  requestId: string
+  /** Status of the response. */
+  status: 'paid' | 'declined'
+  /** Optional note from the payer. */
+  note?: string
+  /** Actual amount paid in satoshis (may differ from the requested amount). */
+  amountPaid?: number
+}
+
+/**
+ * Represents an incoming payment request as returned by listIncomingPaymentRequests().
+ * Combines the transport message metadata with the parsed request body.
+ */
+export interface IncomingPaymentRequest {
+  /** Transport message ID used for acknowledgment. */
+  messageId: string
+  /** Identity key of the requester. */
+  sender: string
+  /** Unique identifier for this request. */
+  requestId: string
+  /** Amount in satoshis requested. */
+  amount: number
+  /** Human-readable reason for the request. */
+  description: string
+  /** Unix timestamp (ms) when the request expires. */
+  expiresAt: number
+  /** If true, this is a cancellation of a previous request. */
+  cancelled?: boolean
+}
+
+/**
+ * Configurable min/max amount limits for incoming payment requests.
+ * Requests outside these bounds are auto-acknowledged and discarded.
+ */
+export interface PaymentRequestLimits {
+  /** Minimum satoshis to accept in a request. Requests below this are discarded. Default: 1000. */
+  minAmount: number
+  /** Maximum satoshis to accept in a request. Requests above this are discarded. Default: 10000000. */
+  maxAmount: number
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,23 +189,44 @@ export interface ListDevicesResponse {
 }
 
 /**
- * Represents a payment request message sent from a requester to a payer.
- * Carried in the 'payment_requests' message box.
+ * Base fields shared by both payment request and cancellation messages.
  */
-export interface PaymentRequestMessage {
+interface PaymentRequestBase {
   /** Unique identifier for this request, generated via createNonce(). */
   requestId: string
+  /** Identity key of the requester, used for correlation and cancellation verification. */
+  senderIdentityKey: string
+}
+
+/**
+ * A new payment request sent from requester to payer.
+ * Carried in the 'payment_requests' message box.
+ */
+export interface PaymentRequestNew extends PaymentRequestBase {
   /** Amount in satoshis being requested. */
   amount: number
   /** Human-readable reason for the request. */
   description: string
   /** Unix timestamp (ms) after which the request expires. Set by the sender. */
   expiresAt: number
-  /** Identity key of the requester, used for correlation on the payer's side. */
-  senderIdentityKey: string
-  /** If true, this message cancels a previously sent request with the same requestId. */
-  cancelled?: boolean
+  /** Omitted or false for a new payment request. */
+  cancelled?: false
 }
+
+/**
+ * A cancellation of a previously sent payment request.
+ * Carried in the 'payment_requests' message box.
+ */
+export interface PaymentRequestCancellation extends PaymentRequestBase {
+  /** If true, this message cancels a previously sent request with the same requestId. */
+  cancelled: true
+}
+
+/**
+ * Discriminated union: either a new payment request or a cancellation.
+ * Discriminant field: `cancelled` (true = cancellation, absent/false = new request).
+ */
+export type PaymentRequestMessage = PaymentRequestNew | PaymentRequestCancellation
 
 /**
  * Represents a response to a payment request, sent from the payer back to the requester.
@@ -225,6 +246,7 @@ export interface PaymentRequestResponse {
 /**
  * Represents an incoming payment request as returned by listIncomingPaymentRequests().
  * Combines the transport message metadata with the parsed request body.
+ * Only active (non-cancelled) requests are returned, so cancelled field is omitted.
  */
 export interface IncomingPaymentRequest {
   /** Transport message ID used for acknowledgment. */
@@ -239,9 +261,12 @@ export interface IncomingPaymentRequest {
   description: string
   /** Unix timestamp (ms) when the request expires. */
   expiresAt: number
-  /** If true, this is a cancellation of a previous request. */
-  cancelled?: boolean
 }
+
+/** Default minimum satoshis for payment request filtering. */
+export const DEFAULT_PAYMENT_REQUEST_MIN_AMOUNT = 1000
+/** Default maximum satoshis for payment request filtering. */
+export const DEFAULT_PAYMENT_REQUEST_MAX_AMOUNT = 10_000_000
 
 /**
  * Configurable min/max amount limits for incoming payment requests.
@@ -249,7 +274,7 @@ export interface IncomingPaymentRequest {
  */
 export interface PaymentRequestLimits {
   /** Minimum satoshis to accept in a request. Requests below this are discarded. Default: 1000. */
-  minAmount: number
+  minAmount?: number
   /** Maximum satoshis to accept in a request. Requests above this are discarded. Default: 10000000. */
-  maxAmount: number
+  maxAmount?: number
 }


### PR DESCRIPTION
## Summary
- Add 11 new methods to PeerPayClient for requesting, fulfilling, declining, cancelling, and tracking payment requests
- Add 3 permission management methods (allow/block/list) for controlling who can send payment requests
- Add 4 new types: PaymentRequestMessage, PaymentRequestResponse, IncomingPaymentRequest, PaymentRequestLimits
- Uses two new message boxes: `payment_requests` and `payment_request_responses`
- Default-deny: `payment_requests` box blocks all senders until explicitly whitelisted
- Client-side min/max amount limits filter out dust and oversized requests

## New Methods

### Request Flow
- `requestPayment()` — send a payment request to a recipient
- `cancelPaymentRequest()` — cancel a pending request
- `listIncomingPaymentRequests()` — list requests with expiry/cancellation/amount-limit filtering
- `fulfillPaymentRequest()` — pay a request and send status response
- `declinePaymentRequest()` — decline a request and send status response
- `listPaymentRequestResponses()` — list responses to outgoing requests
- `listenForLivePaymentRequests()` — WebSocket listener for incoming requests
- `listenForLivePaymentRequestResponses()` — WebSocket listener for responses

### Permission Management
- `allowPaymentRequestsFrom()` — whitelist an identity to send payment requests
- `blockPaymentRequestsFrom()` — block an identity from sending requests
- `listPaymentRequestPermissions()` — list all whitelisted/blocked identities

## Test plan
- [x] Unit tests pass (24 new tests in PeerPayClientUnit.test.ts)
- [x] Integration tests pass (7 tests covering full round-trip flows)
- [x] Full test suite: 63 tests across 4 suites
- [x] Build succeeds (`npm run build`)
- [x] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)